### PR TITLE
Tweak form layout and asking for email

### DIFF
--- a/app/views/_form.njk
+++ b/app/views/_form.njk
@@ -2,29 +2,20 @@
 
 {% block content %}
 <div class="govuk-grid-row">
-  <form class="govuk-grid-column-two-thirds" action="{{ formaction | default('#') }}" method="post">
-  {% set legendHtml %}
+  <div class="govuk-grid-column-two-thirds">
     {% if parent %}
-      <span class="govuk-caption-xl">{{ parent }}</span> {{ title }}
-    {% else %}
-      {{ title | safe }}
+      <span class="govuk-caption-xl">{{ parent }}</span>
     {% endif %}
-  {% endset %}
-  {% call govukFieldset({
-    legend: {
-      html: legendHtml,
-      classes: "govuk-fieldset__legend--xl",
-      isPageHeading: true
-    }
-  }) %}
-    {% block primary %}
-    {% endblock %}
-  {% endcall %}
-  </form>
+    <h1 class="govuk-heading-xl">{{ title | safe }}</h1>
+    <form action="{{ formaction | default('#') }}" method="post">
+    {% call govukFieldset() %}
+      {% block primary %}{% endblock %}
+    {% endcall %}
+    </form>
+  </div>
   {% if hasSecondary %}
   <div class="govuk-grid-column-one-third">
-    {% block secondary %}
-    {% endblock %}
+    {% block secondary %}{% endblock %}
   </div>
   {% endif %}
 </div>

--- a/app/views/account/create-account.njk
+++ b/app/views/account/create-account.njk
@@ -1,15 +1,17 @@
 {% extends "_form.njk" %}
 
-{% set title = "Save and return to your application" %}
+{% set title = "Before you begin" %}
 {% set formaction = "/account/check-email/create-account" %}
 {% set isSignedOut = true %}
+{% block pageNavigation %}{{ govukBackLink({ href: '/' }) }}{% endblock %}
 
 {% block primary %}
-  <p class="govuk-body-l">Please give us your email so we can automatically save your information as you enter it.</p>
+  <p class="govuk-body-l">Please give us your email address so we can automatically save your information as you enter it.</p>
 
   {{ govukInput({
     label: {
-      text: "Your email address"
+      text: "Email address",
+      classes: "govuk-label--m"
     },
     hint: {
       text: "Don’t use a work or university email address you might lose access to"

--- a/app/views/email/confirm-address.njk
+++ b/app/views/email/confirm-address.njk
@@ -8,7 +8,7 @@
   <h1 class="govuk-heading-m">Please confirm your email address</h1>
   {% if action == "create-account" %}
     <p class="govuk-body">Click the link below to confirm your email address and return to the <b>Apply for postgraduate teacher training</b> service.</p>
-    <p><a href="/dashboard">https://apply-for-postgraduate-teacher training.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
+    <p><a href="/application">https://apply-for-postgraduate-teacher training.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
     <p>Your information will then be automatically saved as you enter it.</p>
   {% else %}
     <p class="govuk-body">Click the link below to sign in to the <b>Apply for postgraduate teacher training</b> service.</p>


### PR DESCRIPTION
Don't automatically use legends: For the sake of the prototype, use headings which get given the correct spacing between titles and subsequent labels and fields.

- Match design system for email field (https://design-system.service.gov.uk/patterns/email-addresses/)
- Add a back link
- Revert title to before you begin (save and return felt like a page had been missed in the process)

## Before
![Screen Shot 2019-08-06 at 14 33 43](https://user-images.githubusercontent.com/319055/62544802-630dea80-b858-11e9-915e-e368682bcf7d.png)

## After
![Screen Shot 2019-08-06 at 14 33 19](https://user-images.githubusercontent.com/319055/62544804-63a68100-b858-11e9-8310-ac53ab1ef279.png)
