### PR TITLE
Import modules from Manage prototype

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,4 @@
-/* global $ */
+/* global GOVUK */
 
 // Warn about using the kit in production
 if (window.console && window.console.info) {
@@ -6,5 +6,6 @@ if (window.console && window.console.info) {
 }
 
 $(document).ready(function () {
+  GOVUK.modules.start()
   window.GOVUKFrontend.initAll()
 })

--- a/app/assets/javascripts/modules.js
+++ b/app/assets/javascripts/modules.js
@@ -1,0 +1,61 @@
+;(function (global) {
+  'use strict'
+
+  var $ = global.jQuery
+  var GOVUK = global.GOVUK || {}
+  GOVUK.Modules = GOVUK.Modules || {}
+
+  GOVUK.modules = {
+    find: function (container) {
+      container = container || $('body')
+
+      var modules
+      var moduleSelector = '[data-module]'
+
+      modules = container.find(moduleSelector)
+
+      // Container could be a module too
+      if (container.is(moduleSelector)) {
+        modules = modules.add(container)
+      }
+
+      return modules
+    },
+
+    start: function (container) {
+      var modules = this.find(container)
+
+      for (var i = 0, l = modules.length; i < l; i++) {
+        var module
+        var element = $(modules[i])
+        var type = camelCaseAndCapitalise(element.data('module'))
+        var started = element.data('module-started')
+
+        if (typeof GOVUK.Modules[type] === 'function' && !started) {
+          module = new GOVUK.Modules[type]()
+          module.start(element)
+          element.data('module-started', true)
+        }
+      }
+
+      // eg selectable-table to SelectableTable
+      function camelCaseAndCapitalise (string) {
+        return capitaliseFirstLetter(camelCase(string))
+      }
+
+      // http://stackoverflow.com/questions/6660977/convert-hyphens-to-camel-case-camelcase
+      function camelCase (string) {
+        return string.replace(/-([a-z])/g, function (g) {
+          return g.charAt(1).toUpperCase()
+        })
+      }
+
+      // http://stackoverflow.com/questions/1026069/capitalize-the-first-letter-of-string-in-javascript
+      function capitaliseFirstLetter (string) {
+        return string.charAt(0).toUpperCase() + string.slice(1)
+      }
+    }
+  }
+
+  global.GOVUK = GOVUK
+})(window)

--- a/app/assets/javascripts/modules/edge.js
+++ b/app/assets/javascripts/modules/edge.js
@@ -1,0 +1,22 @@
+;(function (global) {
+  'use strict'
+
+  var GOVUK = global.GOVUK || {}
+  GOVUK.Modules = GOVUK.Modules || {}
+
+  GOVUK.Modules.Edge = function () {
+    this.start = function (element) {
+      element.on('click', 'a[href="#"], .js-edge', alertUser);
+
+      function alertUser(evt) {
+        evt.preventDefault();
+        var target = $(evt.target);
+        var message = target.data('message') || 'Sorry, this hasn’t been built yet'
+
+        alert(message);
+      }
+    }
+  }
+
+  global.GOVUK = GOVUK
+})(window)

--- a/app/views/_includes/scripts.njk
+++ b/app/views/_includes/scripts.njk
@@ -1,4 +1,6 @@
 <script src="/public/javascripts/jquery-1.11.3.js"></script>
+<script src="/public/javascripts/modules.js"></script>
+<script src="/public/javascripts/modules/edge.js"></script>
 
 {% for scriptUrl in extensionConfig.scripts %}
   <script src="{{ scriptUrl }}"></script>

--- a/app/views/_layout.njk
+++ b/app/views/_layout.njk
@@ -87,6 +87,10 @@
   }) }}
 {% endblock %}
 
+{% block bodyStart %}
+  <div data-module="edge">
+{% endblock %}
+
 {% block beforeContent %}
   {{ govukPhaseBanner({
     tag: {
@@ -120,6 +124,8 @@
 {% endif %}
 
 {% block bodyEnd %}
+  </div>
+
   {% block scripts %}
     {{ data | log }}
     {% include "_includes/scripts.njk" %}


### PR DESCRIPTION
- Use a `data-module` pattern to invoke JS modules
- Add an edge module to warn if a user clicks a link that doesn't go anywhere