### PR TITLE
Fix personal details review flows

### DIFF
--- a/app/routes/application/personal-details.js
+++ b/app/routes/application/personal-details.js
@@ -1,28 +1,30 @@
+const utils = require('./../../utils')
+
 /**
  * Application: Personal details routes
  */
 module.exports = router => {
   // First page
   router.get('/application/:applicationId/personal-details', (req, res) => {
-    const referrer = req.query.referrer
-
     res.render('application/personal-details/index', {
-      formaction: referrer || `/application/${req.params.applicationId}/personal-details/answer`,
-      referrer
+      formaction: `/application/${req.params.applicationId}/personal-details/answer?${utils.queryString(req)}`
     })
   })
 
   // Residency status answer branching
   router.post('/application/:applicationId/personal-details/answer', (req, res) => {
     const applicationId = req.params.applicationId
-    const nationality = req.session.data.applications[applicationId]['candidate']['nationality']
+    const applicationData = req.session.data.applications[applicationId]
+    const nationality = applicationData['candidate']['nationality']
 
     const eea = ['Austrian', 'Belgian', 'Bulgarian', 'Croatian', 'Cypriot', 'Czech', 'Danish', 'Dutch', 'Estonian', 'Finnish', 'French', 'German', 'Greek', 'Hungarian', 'Icelandic', 'Irish', 'Italian', 'Latvian', 'Liechtenstein citizen', 'Lithuanian', 'Luxembourger', 'Maltese', 'Norwegian', 'Polish', 'Portuguese', 'Romanian', 'Slovak', 'Slovenian', 'Spanish', 'Swedish', 'Swiss', 'British']
 
     if (eea.includes(nationality)) {
-      res.redirect(`/application/${applicationId}`)
+      // Delete residency status if previously entered
+      delete applicationData['candidate']['residency-status']
+      res.redirect(`/application/${applicationId}/personal-details/review`)
     } else {
-      res.redirect(`/application/${applicationId}/personal-details/residency-status`)
+      res.redirect(`/application/${applicationId}/personal-details/residency-status?${utils.queryString(req)}`)
     }
   })
 

--- a/app/views/_includes/review-personal-details.njk
+++ b/app/views/_includes/review-personal-details.njk
@@ -117,7 +117,7 @@
 {% if residencyStatus %}
   {{ govukSummaryList({
     classes: "app-summary",
-    rows: [nameRow, nationalityRow, languageRow, residencyStatusRow]
+    rows: [nameRow, nationalityRow, residencyStatusRow, languageRow]
   }) }}
 {% else %}
   {{ govukSummaryList({


### PR DESCRIPTION
* Fixes review page not appearing after entering personal details
* Fixes flow so that whenever you enter a non-EEA nationality, you are asked for residency status
* Fixes submitted data such that if you enter a non-EEA nationality and residency status answer, but then change back to a EEA nationality, residency status answer is removed (and thus not shown on application)