### PR TITLE
Make autocomplete arrow clickable

### DIFF
--- a/app/assets/sass/components/_autocomplete.scss
+++ b/app/assets/sass/components/_autocomplete.scss
@@ -129,3 +129,8 @@
 .autocomplete__option {
   padding: govuk-spacing(1);
 }
+
+// https://github.com/alphagov/accessible-autocomplete/issues/202
+.autocomplete__dropdown-arrow-down {
+  pointer-events: none;
+}


### PR DESCRIPTION
Relates to https://github.com/alphagov/accessible-autocomplete/issues/202

This isn't an ideal fix but is fine for prototyping.