### PR TITLE
Create an application submitted email

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -73,6 +73,10 @@ module.exports = router => {
     res.render(`application/confirmation`)
   })
 
+  router.all('/application/:applicationId/submitted', (req, res) => {
+    res.render(`email/application-submitted`)
+  })
+
   // Render provided view, or index template for that view if not found
   router.all('/application/:applicationId/:view', (req, res) => {
     const referrer = req.query.referrer

--- a/app/views/application/confirmation.njk
+++ b/app/views/application/confirmation.njk
@@ -3,11 +3,14 @@
 {% set title = "Application submitted" %}
 
 {% block content %}
-  {% set panelText %}Thank you for applying for postgraduate teacher training{% endset %}
+  {% set panelText %}
+    <a class="app-hidden-link" href="/application/{{ applicationId }}/submitted">Thank you for applying for postgraduate teacher training</a>
+  {% endset %}
+
   {{ govukPanel({
     classes: "govuk-!-margin-bottom-8",
     titleText: "Application submitted",
-    text: panelText
+    html: panelText
   }) }}
 
   <div class="govuk-grid-row">

--- a/app/views/email/application-submitted.njk
+++ b/app/views/email/application-submitted.njk
@@ -1,0 +1,23 @@
+{% extends "_email.njk" %}
+
+{% set title = "Thank you for submitting your teacher training application" %}
+{% set from = "noreply@apply-for-teacher-training.service.gov.uk" %}
+{% set to = data.candidate["email"] %}
+{% set courses = applicationValue("courses") | toArray %}
+
+{% block content %}
+  <h1 class="govuk-heading-m">Thank you for submitting your teacher training application</h1>
+
+  <p>You have successfully submitted an application to:</p>
+  {% for c in courses %}
+    {% set provider = providers[c.providerCode] %}
+    {% set course = provider.courses[c.courseCode] %}
+    <p>{{ provider.name }}<br />{{ course.name_and_code }}</p>
+  {% endfor %}
+
+  <p>You can track the progress of your application here:<br /><a href="/applications">https://apply-for-postgraduate-teacher-training.service.gov.uk/applications</a></p>
+
+  <p>Your training provider will respond to your application within 40 working days via email. If they decide to progress your application, they will communicate with you directly to organise an interview date and give you all the information you need.</p>
+
+  <p>You can apply to as many different training providers as you like. If you’re ready to apply to another training provider, visit the <a href="/applications">Applications</a> page to start a new application.</p>
+{% endblock %}


### PR DESCRIPTION
- Secretly link to it from confirmation page
- List courses applied to
- Link back to the Applications page to see status

Content will be looked at separately by @laurahermionetennant92, words based on initial version we tried on Find in March.