### PR TITLE
add "2020" as year to "date by which providers must respond"

### DIFF
--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -24,7 +24,7 @@
     {% if application.status == 'submitted' %}
       <h3 class="govuk-heading-l">Application submitted {{ "now" | date("d MMMM yyyy") }}</h3>
       <p><a href="/application/{{ applicationId }}/submitted">View application</a></p>
-      <p>Training providers must respond by 29 July.</p>
+      <p>Training providers must respond by 29 July 2020.</p>
 
       {% for id, c in application.courses %}
         {% set provider = providers[c.providerCode] %}


### PR DESCRIPTION
### Date now says "2020"
<img width="625" alt="Screenshot 2019-09-12 at 08 55 37" src="https://user-images.githubusercontent.com/50486078/64764970-29a55a80-d53b-11e9-8d81-e814f306545e.png">

[https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-prototype/issues/153](Date by which providers must respond)
