### PR TITLE
Tweaks for user research instance

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,5 +1,5 @@
 module.exports = {
-  applications: {
+  disabled_applications: {
     12345: {
       status: 'started',
       courses: {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,7 +1,7 @@
 const utils = require('./../utils')
 
 function createNewApplication (req) {
-  var code = utils.generateRandomString()
+  var code = req.app.locals.urStudy || utils.generateRandomString()
   var data = req.session.data
 
   if (typeof data.applications === 'undefined') {

--- a/app/views/_layout.njk
+++ b/app/views/_layout.njk
@@ -105,7 +105,7 @@
         }, {
           href: "/prototype-admin/clear-data",
           text: "Clear data"
-        } if urStudy != true ]
+        } if not urStudy]
       }
     }) }}
   {% endblock %}

--- a/app/views/application/contact-details/index.njk
+++ b/app/views/application/contact-details/index.njk
@@ -30,8 +30,26 @@
     type: "tel"
   } | decorateApplicationAttributes(["contact-details", "phone-number"])) }}
 
+{% if urStudy %}
+  {{ govukInput({
+    id: "account-email",
+    name: "account[email]",
+    value: data["account"]["email"],
+    label: {
+      text: "Email address",
+      classes: "govuk-label--m"
+    },
+    hint: {
+      text: "Don’t use a work or university email address you might lose access to"
+    },
+    classes: "govuk-input--width-20",
+    autocomplete: "tel",
+    type: "tel"
+  }) }}
+{% else %}
   <h3 class="govuk-heading-m govuk-!-margin-bottom-2">Email address</h3>
   <p class="govuk-body">{{ data["account"]["email"] }} &nbsp; <a href="/account/change-email-address">Change</a></p>
+{% endif %}
 
   {{ govukButton({
     text: "Continue"

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -4,7 +4,7 @@
 
 {% block primary %}
   {% for applicationId, application in data.applications %}
-    {% if application.status == 'submitted' %}
+    {% if application.status == "submitted" %}
       <p>You submitted your application on {{ "now" | date("d MMMM yyyy") }}. Training providers must respond to you by {{ 40 | nowPlusDays("d MMMM yyyy") }}.</p>
 
       {% if true or (notAlreadyEdited and within1WeekOfSubmitting) %}

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -19,12 +19,31 @@
   <h2 class="govuk-heading-m">If you don’t have a degree</h2>
   <p class="govuk-body">You can teach in further education (age 14 to adult), or study for a degree leading to qualified teacher status. <a href="https://getintoteaching.education.gov.uk/eligibility-for-teacher-training">Learn more</a>.</p>
 
+{% if urStudy %}
+  {{ govukWarningText({
+    text: "Please remember to record your session using Lookback.",
+    iconFallbackText: "Warning"
+  }) }}
+  {% if data.applications[urStudy] %}
+    {{ govukButton({
+      text: "Return to application",
+      href: "/application/" + urStudy,
+      isStartButton: true
+    }) }}
+  {% else %}
+    {{ govukButton({
+      text: "Start now",
+      href: "/application/" + urStudy,
+      isStartButton: true
+    }) }}
+  {% endif %}
+{% else %}
   {{ govukButton({
     text: "Start now",
     href: "/account/create-account",
     isStartButton: true,
     classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-3"
   }) }}
-
   <p class="govuk-body">If you have teacher training applications in progress, please <a href="/account/sign-in">sign in</a></p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
- Value of `UR_STUDY` is now used as application ID (if exists)
- Update routes so that if `UR_STUDY`, use that to create new application ID
- Update landing page with different calls to action if user study, and if user is returning
- Update landing page with notice for candidates to record their session
- Fix ‘Clear data’ link in footer