### PR TITLE
Link to `/application/start` rather than `/application/CODE`

### DIFF
--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -33,7 +33,7 @@
   {% else %}
     {{ govukButton({
       text: "Start now",
-      href: "/application/" + urStudy,
+      href: "/application/start",
       isStartButton: true
     }) }}
   {% endif %}


### PR DESCRIPTION
The start method sets up the objects we need to attach things like courses to. Without going through this you can't add courses to an application.

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-prototype/blob/master/app/routes/application.js#L3-L13