### PR TITLE
Show personal statements when entered

### DIFF
--- a/app/views/_includes/review-personal-statement.njk
+++ b/app/views/_includes/review-personal-statement.njk
@@ -11,7 +11,7 @@
     actions: {
       items: [{
         classes: "govuk-!-padding-right-2",
-        href: applicationPath + "/personal-statement/" + statementId + "/vocation?referrer=" + referrer,
+        href: applicationPath + "/personal-statement/" + providerCode + "/vocation?referrer=" + referrer,
         text: "Change" if statement["vocation"] else "Add",
         visuallyHiddenText: "why you want to be a teacher"
       }]
@@ -26,7 +26,7 @@
     actions: {
       items: [{
         classes: "govuk-!-padding-right-2",
-        href: applicationPath + "/personal-statement/" + statementId + "/subject-knowledge?referrer=" + referrer,
+        href: applicationPath + "/personal-statement/" + providerCode + "/subject-knowledge?referrer=" + referrer,
         text: "Change" if statement["vocation"] else "Add",
         visuallyHiddenText: "evidence of subject knowledge"
       }]
@@ -41,7 +41,7 @@
     actions: {
       items: [{
         classes: "govuk-!-padding-right-2",
-        href: applicationPath + "/personal-statement/" + statementId + "/interview?referrer=" + referrer,
+        href: applicationPath + "/personal-statement/" + providerCode + "/interview?referrer=" + referrer,
         text: "Change" if statement["vocation"] else "Add",
         visuallyHiddenText: "evidence of subject knowledge"
       }]

--- a/app/views/_includes/review-personal-statement.njk
+++ b/app/views/_includes/review-personal-statement.njk
@@ -11,7 +11,7 @@
     actions: {
       items: [{
         classes: "govuk-!-padding-right-2",
-        href: applicationPath + "/personal-statement/" + statement.id + "/vocation?referrer=" + referrer,
+        href: applicationPath + "/personal-statement/" + statementId + "/vocation?referrer=" + referrer,
         text: "Change" if statement["vocation"] else "Add",
         visuallyHiddenText: "why you want to be a teacher"
       }]
@@ -26,7 +26,7 @@
     actions: {
       items: [{
         classes: "govuk-!-padding-right-2",
-        href: applicationPath + "/personal-statement/" + statement.id + "/subject-knowledge?referrer=" + referrer,
+        href: applicationPath + "/personal-statement/" + statementId + "/subject-knowledge?referrer=" + referrer,
         text: "Change" if statement["vocation"] else "Add",
         visuallyHiddenText: "evidence of subject knowledge"
       }]
@@ -41,7 +41,7 @@
     actions: {
       items: [{
         classes: "govuk-!-padding-right-2",
-        href: applicationPath + "/personal-statement/" + statement.id + "/interview?referrer=" + referrer,
+        href: applicationPath + "/personal-statement/" + statementId + "/interview?referrer=" + referrer,
         text: "Change" if statement["vocation"] else "Add",
         visuallyHiddenText: "evidence of subject knowledge"
       }]

--- a/app/views/application/personal-statement/review.njk
+++ b/app/views/application/personal-statement/review.njk
@@ -23,7 +23,6 @@
     </ul>
   {% endif %}
   {% set statement = applicationValue(["personal-statements", providerCode]) %}
-  {% set statementId = providerCode %}
   {% include "_includes/review-personal-statement.njk" %}
 
   {{ govukButton({

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -58,8 +58,8 @@
   {% include "_includes/review-other-qualifications.njk" %}
 
   <h2 class="govuk-heading-l">Personal statement and interview</h2>
-  {% for statementId, statement in applicationValue(["personal-statements"]) %}
-    <h3 class="govuk-heading-m">{{ providers[statementId].name }}</h3>
+  {% for providerCode, statement in applicationValue(["personal-statements"]) %}
+    <h3 class="govuk-heading-m">{{ providers[providerCode].name }}</h3>
     {% include "_includes/review-personal-statement.njk" %}
   {% endfor %}
 

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -58,8 +58,8 @@
   {% include "_includes/review-other-qualifications.njk" %}
 
   <h2 class="govuk-heading-l">Personal statement and interview</h2>
-  {% for statement in applicationValue(["personal-statements"]) | toArray %}
-    <h3 class="govuk-heading-m">{{ providers[statement.id].name }}</h3>
+  {% for statementId, statement in applicationValue(["personal-statements"]) %}
+    <h3 class="govuk-heading-m">{{ providers[statementId].name }}</h3>
     {% include "_includes/review-personal-statement.njk" %}
   {% endfor %}
 


### PR DESCRIPTION
Previously we were using `statement.id` to link to the statement forms, but on the application section this was undefined, meaning the values were being added to the wrong place.

Use statementId consistently, using the Nunjucks way of looping through an object’s keys and values.

Fixes #171
Caused by 2c863729cc536cdc3fa8200b3e76043885114cc2