### PR TITLE
Prefer not to say

### DIFF
--- a/app/views/_includes/review-equality-monitoring.njk
+++ b/app/views/_includes/review-equality-monitoring.njk
@@ -1,7 +1,7 @@
 {% set path = "/application/" + applicationId + "/equality-monitoring/" %}
 
 {% set disabilityText %}
-  {% if applicationValue(["equality-monitoring", "disability-status"]).includes("Yes") %}
+  {% if applicationValue(["equality-monitoring", "disability-status"]) == "Yes" %}
     {{ applicationValue(["equality-monitoring", "disability-status"]) }}
     {% set disabilities = applicationValue(["equality-monitoring", "disabilities"]) %}
     {% if disabilities.length >= 1 %}
@@ -13,15 +13,23 @@
         {%- endif -%}
       {%- endfor -%})
     {% endif %}
-  {% else %}
+  {% elif applicationValue(["equality-monitoring", "disability-status"]) %}
     {{ applicationValue(["equality-monitoring", "disability-status"]) }}
+  {% else %}
+    Not entered
   {% endif %}
 {% endset %}
 
 {% set ethnicGroupText %}
-  {{ applicationValue(["equality-monitoring", "ethnic-group"]) }}
-  {% if not applicationValue(["equality-monitoring", "ethnic-group"]).includes("Prefer not to say") %}
-    ({{ applicationValue(["equality-monitoring", "ethnic-background-other"]) or applicationValue(["equality-monitoring", "ethnic-background"]) }})
+  {% if applicationValue(["equality-monitoring", "ethnic-group"]) %}
+    {{ applicationValue(["equality-monitoring", "ethnic-group"]) }}
+    {% if applicationValue(["equality-monitoring", "ethnic-group"]) != "Prefer not to say" %}
+      {% if applicationValue(["equality-monitoring", "ethnic-background"]) != "Prefer not to say" %}
+        ({{ applicationValue(["equality-monitoring", "ethnic-background-other"]) or applicationValue(["equality-monitoring", "ethnic-background"]) }})
+      {% endif %}
+    {% endif %}
+  {% else %}
+    Not entered
   {% endif %}
 {% endset %}
 

--- a/app/views/application/equality-monitoring/disability-status.njk
+++ b/app/views/application/equality-monitoring/disability-status.njk
@@ -14,10 +14,6 @@
       text: "Yes"
     }, {
       text: "No"
-    }, {
-      divider: "or"
-    }, {
-      text: "Prefer not to say"
     }]
   } | decorateApplicationAttributes(["equality-monitoring", "disability-status"])) }}
 

--- a/app/views/application/equality-monitoring/sex.njk
+++ b/app/views/application/equality-monitoring/sex.njk
@@ -16,10 +16,6 @@
       text: "Male"
     }, {
       text: "Intersex"
-    }, {
-      divider: "or"
-    }, {
-      text: "Prefer not to say"
     }]
   } | decorateApplicationAttributes(["equality-monitoring", "sex"])) }}
 


### PR DESCRIPTION
- Remove ‘Prefer not to say’ on disability and sex equality monitoring questions
- Fix `the return value of (applicationValue)["includes"]` error on  equality monitoring review page
- Fix logic around display of ethic backgrounds w/r/t ‘Prefer not to say’ for group/background.

Fixes #178.