### PR TITLE
Add feature flag for automatic gaps in work history

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,6 +1,7 @@
 module.exports = {
   flags: {
     address_lookup: false,
+    automatic_gaps: false,
     international_address: true,
     international_qualifications: true,
     nationality: true,

--- a/app/views/_includes/review/work-history.njk
+++ b/app/views/_includes/review/work-history.njk
@@ -1,11 +1,16 @@
 {% set applicationPath = "/application/" + applicationId %}
+
 {% set workHistory = applicationValue("work-history")
   | toArray
   | sort(attribute="start-date")
   | selectattr("id")
 %}
 
-{% if workHistory.length >= 1 %}
+{% set hasHistory = workHistory | toArray | length >= 1 %}
+{% set hasMissing = applicationValue(["work-history", "length"]) == "none" and not hasHistory %}
+{% set hasAutomaticGaps = data.flags.automatic_gaps == true %}
+
+{% if hasHistory and not hasMissing %}
   {% for item in workHistory %}
     {% set jobHtml %}
       {% include "_includes/item/job.njk" %}
@@ -15,32 +20,34 @@
       {% include "_includes/item/gap.njk" %}
     {% endset %}
 
-    {# periodStart = Earliest date in required work history period #}
-    {% set periodStart = "now" | date | replace("2019", "2014") %}
-    {% set periodStartEpoch = periodStart | date("x") %}
+    {% if hasAutomaticGaps %}
+      {# periodStart = Earliest date in required work history period #}
+      {% set periodStart = "now" | date | replace("2019", "2014") %}
+      {% set periodStartEpoch = periodStart | date("x") %}
 
-    {# firstStart = Start date of first item in work history #}
-    {% set firstStart = item["start-date"] %}
-    {% set firstStartEpoch = firstStart | date("x") %}
+      {# firstStart = Start date of first item in work history #}
+      {% set firstStart = item["start-date"] %}
+      {% set firstStartEpoch = firstStart | date("x") %}
 
-    {% if loop.first and firstStartEpoch > periodStartEpoch %}
-      {# Unexplained gap (prior to work history commencing) #}
-      {% set itemStart = periodStart %}
-      {% set itemStartEpoch = itemStart | date("x") %}
-      {% set itemEnd = firstStart %}
-      {% set itemEndEpoch = itemEnd | date("x") %}
-      {% set itemDuration = itemEndEpoch - itemStartEpoch %}
-      {{ appSummaryCard({
-        classes: "govuk-!-margin-bottom-6",
-        headingLevel: 3,
-        titleText: "Unexplained gap (" + (itemDuration | duration) + ")",
-        actions: {
-          items: [{
-            href: applicationPath + "/work-history/add/gap?start=" + itemStart | date("yyyy-LL") + "&end=" + itemEnd | date("yyyy-LL") + "&referrer=" + referrer,
-            text: "Explain gap"
-          }]
-        } if review == true
-      }) }}
+      {% if loop.first and firstStartEpoch > periodStartEpoch %}
+        {# Unexplained gap (prior to work history commencing) #}
+        {% set itemStart = periodStart %}
+        {% set itemStartEpoch = itemStart | date("x") %}
+        {% set itemEnd = firstStart %}
+        {% set itemEndEpoch = itemEnd | date("x") %}
+        {% set itemDuration = itemEndEpoch - itemStartEpoch %}
+        {{ appSummaryCard({
+          classes: "govuk-!-margin-bottom-6",
+          headingLevel: 3,
+          titleText: "Unexplained gap (" + (itemDuration | duration) + ")",
+          actions: {
+            items: [{
+              href: applicationPath + "/work-history/add/gap?start=" + itemStart | date("yyyy-LL") + "&end=" + itemEnd | date("yyyy-LL") + "&referrer=" + referrer,
+              text: "Explain gap"
+            }]
+          } if review == true
+        }) }}
+      {% endif %}
     {% endif %}
 
     {% if item.category == "gap" %}
@@ -71,28 +78,56 @@
       }) }}
     {% endif %}
 
-    {# Unexplained gap (during work history) #}
-    {% set nextItem = workHistory[loop.index] %}
-    {% set itemStart = item["end-date"] %}
-    {% set itemStartEpoch = itemStart | date("x") %}
-    {% set itemEnd = nextItem["start-date"] if nextItem else "now" %}
-    {% set itemEndEpoch = itemEnd | date("x") %}
-    {% set itemDuration = itemEndEpoch - itemStartEpoch %}
-    {% if itemEndEpoch > itemStartEpoch and itemDuration > 2678400000 %}
-      {{ appSummaryCard({
-        classes: "govuk-!-margin-bottom-6",
-        headingLevel: 3,
-        titleText: "Unexplained gap (" + (itemDuration | duration) + ")",
-        actions: {
-          items: [{
-            href: applicationPath + "/work-history/add/gap?start=" + itemStart | date("yyyy-LL") + "&end=" + itemEnd | date("yyyy-LL") + "&referrer=" + referrer,
-            text: "Explain gap"
-          }]
-        } if review == true
-      }) }}
+    {% if hasAutomaticGaps %}
+      {# Unexplained gap (during work history) #}
+      {% set nextItem = workHistory[loop.index] %}
+      {% set itemStart = item["end-date"] %}
+      {% set itemStartEpoch = itemStart | date("x") %}
+      {% set itemEnd = nextItem["start-date"] if nextItem else "now" %}
+      {% set itemEndEpoch = itemEnd | date("x") %}
+      {% set itemDuration = itemEndEpoch - itemStartEpoch %}
+      {% if itemEndEpoch > itemStartEpoch and itemDuration > 2678400000 %}
+        {{ appSummaryCard({
+          classes: "govuk-!-margin-bottom-6",
+          headingLevel: 3,
+          titleText: "Unexplained gap (" + (itemDuration | duration) + ")",
+          actions: {
+            items: [{
+              href: applicationPath + "/work-history/add/gap?start=" + itemStart | date("yyyy-LL") + "&end=" + itemEnd | date("yyyy-LL") + "&referrer=" + referrer,
+              text: "Explain gap"
+            }]
+          } if review == true
+        }) }}
+      {% endif %}
     {% endif %}
   {% endfor %}
-{% elif applicationValue(["work-history", "missing"]) and not workHistory.length %}
+  {% if not hasAutomaticGaps %}
+    {% set gapsHtml %}
+      {{ govukSummaryList({
+        classes: "app-summary",
+        rows: [{
+          key: {
+            text: "Reasons for any gaps in your work history"
+          },
+          value: {
+            text: applicationValue(["work-history", "gaps"]) or "None provided" | nl2br | safe
+          },
+          actions: {
+            items: [{
+              href: applicationPath + "/work-history/explain-gaps?referrer=" + referrer,
+              text: "Change",
+              visuallyHiddenText: "reasons"
+            }]
+          }
+        }]
+      }) }}
+    {% endset %}
+    {{ appSummaryCard({
+      classes: "govuk-!-margin-bottom-6",
+      html: gapsHtml
+    }) }}
+  {% endif %}
+{% elif hasMissing %}
   {% set outofWorkHtml %}
     {{ govukSummaryList({
       classes: "app-summary",
@@ -101,10 +136,9 @@
           text: "Explanation of why you’ve been out of the workplace"
         },
         value: {
-          text: applicationValue(["work-history", "missing"]) | nl2br | safe
+          text: applicationValue(["work-history", "missing"]) or "Not entered" | nl2br | safe
         },
         actions: {
-          classes: "govuk-!-padding-right-2",
           items: [{
             href: applicationPath + "/work-history/missing?referrer=" + referrer,
             text: "Change",

--- a/app/views/application/work-history/explain-gaps.njk
+++ b/app/views/application/work-history/explain-gaps.njk
@@ -1,0 +1,37 @@
+{% extends "_form.njk" %}
+
+{% set applicationPath = "/application/" + applicationId %}
+{% if referrer %}
+  {% set formaction = referrer %}
+{% else %}
+  {% set formaction = applicationPath + "/work-history/review" %}
+{% endif %}
+{% set parent = "Work history" %}
+{% set title = "Explain gaps in work history" %}
+
+{% block pageNavigation %}
+  {% if referrer %}
+    {{ govukBackLink({ href: referrer }) }}
+  {% else %}
+    {{ govukBackLink({ href: applicationPath + "/work-history" }) }}
+  {% endif %}
+{% endblock %}
+
+{% block primary %}
+  {{ referrer }}
+  {{ govukCharacterCount({
+    label: {
+        text: "Gaps in work history",
+      classes: "govuk-label--m"
+    },
+    hint: {
+      text: "Have you taken time off work for any reason? (Examples might include study, caring responsibilities, travel, a career break or health.) If so, please give us details. You should explain any gap longer than a month."
+    },
+    rows: 10,
+    maxwords: 400
+  } | decorateApplicationAttributes(["work-history", "gaps"])) }}
+
+  {{ govukButton({
+    text: "Continue"
+  }) }}
+{% endblock %}

--- a/app/views/application/work-history/index.njk
+++ b/app/views/application/work-history/index.njk
@@ -44,7 +44,7 @@
       conditional: {
         html: "<p class=\"govuk-body\">You’ll be able to give details once you’ve entered your employment history. We’ll ask you to explain any gap longer than a month.</p>"
       }
-    }, {
+    } if data.flags.automatic_gaps, {
       value: "none",
       text: "I have not worked in the last 5 years",
       conditional: {

--- a/app/views/application/work-history/review.njk
+++ b/app/views/application/work-history/review.njk
@@ -14,7 +14,7 @@
 
 {% block primary %}
   {% include "_includes/review/work-history.njk" %}
-  {% if not applicationValue(["work-history","missing"]) %}
+  {% if applicationValue(["work-history", "length"]) != "none" %}
     {{ govukButton({
       text: "Add another job",
       classes: "govuk-button--secondary",


### PR DESCRIPTION
* Adds `automatic_gaps` feature flag and sets it to `false`.
* If `true`, gaps longer 1 month appear in work history, with option for candidate to provide explanation for each
* If `false`:
  * Removes “More than 5 years, but with gaps” option from work history introduction page 
  * Removes display of automatic gaps in work history
  * Provides a summary card after last item in work history with the option to add reasons for any gaps
  * This links to a new page “Explain gaps in work history”.

## Reviewing work history with automatically generated gaps

<img width="1010" alt="Screenshot 2019-09-23 at 14 23 05" src="https://user-images.githubusercontent.com/813383/65429275-cdc9b400-de0d-11e9-9898-aec96b4bb38f.png">

## Reviewing work history with no automatically generated gaps

<img width="1010" alt="Screenshot 2019-09-23 at 14 29 08" src="https://user-images.githubusercontent.com/813383/65429706-8e4f9780-de0e-11e9-96ca-4fed9ed6775d.png">

## Explain gaps in work history

![Screen Shot 2019-09-23 at 14 23 41](https://user-images.githubusercontent.com/813383/65429357-f2be2700-de0d-11e9-870a-2b4ae04e915a.png)
