### PR TITLE
Print styles

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -5,7 +5,7 @@ $govuk-global-styles: true;
 // Import GOV.UK Frontend and any extension styles if configured
 @import "lib/extensions/extensions";
 
-// Components that aren't in Frontend
+// Components that aren’t in Frontend
 @import "components/autocomplete";
 @import "components/caption";
 @import "components/course";
@@ -18,3 +18,24 @@ $govuk-global-styles: true;
 @import "components/table";
 @import "components/task-list";
 @import "components/tag";
+
+// Override GOV.UK Frontend print styles
+@media print {
+  .govuk-template {
+    background-color: transparent;
+  }
+
+  .govuk-width-container {
+    max-width: 95%;
+  }
+
+  .govuk-button,
+  .govuk-back-link,
+  .govuk-footer,
+  .govuk-header__menu-button,
+  .govuk-header__navigation,
+  .govuk-phase-banner,
+  .govuk-summary-list__actions {
+    display: none !important;
+  }
+}

--- a/app/assets/sass/components/_course.scss
+++ b/app/assets/sass/components/_course.scss
@@ -26,3 +26,9 @@
   @include govuk-font($size: 16);
   margin-bottom: govuk-spacing(0);
 }
+
+@media print {
+  .app-course a::after {
+    display: none;
+  }
+}

--- a/app/assets/sass/components/_summary-card.scss
+++ b/app/assets/sass/components/_summary-card.scss
@@ -32,3 +32,13 @@
     border-bottom: 0;
   }
 }
+
+@media print {
+  .app-summary-card__header {
+    break-inside: avoid;
+  }
+
+  .app-summary-card__actions {
+    display: none;
+  }
+}

--- a/app/assets/sass/components/_task-list.scss
+++ b/app/assets/sass/components/_task-list.scss
@@ -50,6 +50,12 @@
   }
 }
 
+@media print {
+  .app-task-list__task-name::after {
+    display: none;
+  }
+}
+
 .app-task-list__task-completed {
   margin-top: govuk-spacing(2);
   margin-bottom: govuk-spacing(1);


### PR DESCRIPTION
Updates styles to remove unnecessary links, buttons and navigation elements appearing when pages are printed. Beyond being suggested changes for the service, in the meantime these changes will allow us to create usable PDF version of any applications submitted via the prototype.

<img width="460" alt="Screenshot 2019-09-24 at 11 39 45" src="https://user-images.githubusercontent.com/813383/65505049-4be69300-dec0-11e9-9029-3d3f54b444a4.png">
