### PR TITLE
Use shorter name, and add (more) placeholders for service name and slug

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -4,7 +4,7 @@
 
 module.exports = {
   // Service name used in header. Eg: 'Renew your passport'
-  serviceName: 'Apply for postgraduate teacher training',
+  serviceName: 'Apply for teacher training',
 
   // Default port that prototype runs on
   port: '3000',

--- a/app/views/_email.njk
+++ b/app/views/_email.njk
@@ -16,7 +16,7 @@
   <dl class="govuk-email__header">
     <div class="govuk-email__header-from">
       <dt class="govuk-visually-hidden">From:</dt>
-      <dd><b>{{ from }}</b><dd>
+      <dd><b>{{ serviceSlug }}@education.gov.uk</b><dd>
     </div>
     <div class="govuk-email__header-subject">
       <dt class="govuk-visually-hidden">Subject:</dt>

--- a/app/views/email/application-submitted.njk
+++ b/app/views/email/application-submitted.njk
@@ -19,14 +19,14 @@
     </li>
   {% endfor %}
   </ul>
-  <p class="govuk-body">You can track the progress of your application here:<br /><a href="/applications">https://apply-for-postgraduate-teacher-training.service.gov.uk/applications</a></p>
+  <p class="govuk-body">You can track the progress of your application here:<br /><a href="/applications">https://{{ serviceSlug }}.service.gov.uk/applications</a></p>
   <p class="govuk-body"><strong>Your application reference is {{ applicationId }}</strong></p>
 
   <h2 class="govuk-heading-m">Next steps</h2>
   <h3 class="govuk-heading-s">References</h3>
-  <p class="govuk-body">The Apply for teacher training service will now contact your referees to ask them for references.</p>
+  <p class="govuk-body">The {{ serviceName}} service will now contact your referees to ask them for references.</p>
   <p class="govuk-body">Your referees will be given a short questionnaire about you and a free text box to describe you in their own words. They will not be given access to your completed application form.</p>
-  <p class="govuk-body">The Apply service will send 1 reminder email to your referees after 5 days. If we haven’t heard back from them after 10 days, or they refuse to give a reference, we’ll get back in touch with you to ask for a replacement.</p>
+  <p class="govuk-body">We will send a reminder email to your referees after 5 days. If we haven’t heard back from them after 10 days, or they refuse to give a reference, we’ll get back in touch with you to ask for a replacement.</p>
 
   <h3 class="govuk-heading-s">Interview</h3>
   <p class="govuk-body">Most training providers don’t reach a decision about interview until they’ve seen references.</p>

--- a/app/views/email/confirm-address.njk
+++ b/app/views/email/confirm-address.njk
@@ -1,21 +1,20 @@
 {% extends "_email.njk" %}
 
 {% set title = "Please confirm your email address" %}
-{% set from = "apply-for-teacher-training@education.gov.uk" %}
 {% set to = data.account.email %}
 
 {% block content %}
   <h1 class="govuk-heading-m">Please confirm your email address</h1>
   {% if action == "create-account" %}
     <p>Click the link below to confirm your email address and go back to the <b>Apply for postgraduate teacher training</b> service.</p>
-    <p><a href="/application/start">https://apply-for-postgraduate-teacher-training.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
+    <p><a href="/application/start">https://{{ serviceSlug }}.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
     <p>You will then be able to save and return to your application.</p>
   {% elif action == "change-email-address" %}
     <p>You have successfully changed the email address you use to sign in to the <b>Apply for postgraduate teacher training</b> service.</p>
     <p>Click on the link below to return to the service.</p>
-    <p><a href="/applications">https://apply-for-postgraduate-teacher-training.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
+    <p><a href="/applications">https://{{ serviceSlug }}.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
   {% else %}
     <p>Click the link below to sign in to the <b>Apply for postgraduate teacher training</b> service.</p>
-    <p><a href="/applications">https://apply-for-postgraduate-teacher-training.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
+    <p><a href="/applications">https://{{ serviceSlug }}.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
   {% endif %}
 {% endblock %}

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -5,7 +5,7 @@
 {% set isSignedOut = true %}
 
 {% block primary %}
-  <p class="govuk-body">Apply for postgraduate teacher training is a new GOV.UK service being trialled with a small number of training providers.</p>
+  <p class="govuk-body">{{ serviceName}} is a new GOV.UK service being trialled with a small number of training providers.</p>
 
   <h2 class="govuk-heading-m">What you’ll need</h2>
   <p class="govuk-body">To be eligible for teacher training, you need these qualifications (or their non-UK equivalents):</p>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "apply-for-postgraduate-teacher-training",
+  "name": "apply-for-teacher-training",
   "description": "Prototype for the ‘Apply for postgraduate teacher training’ service",
   "version": "9.0.0",
   "private": true,

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ const middleware = [
   require('./lib/middleware/extensions/extensions.js')
 ]
 const config = require('./app/config.js')
-const packageJson = require('./package.json')
+const pkg = require('./package.json')
 const routes = require('./app/routes.js')
 const utils = require('./lib/utils.js')
 const extensions = require('./lib/extensions/extensions.js')
@@ -34,7 +34,7 @@ const handleCookies = utils.handleCookies(app)
 app.use(handleCookies)
 
 // Set up configuration variables
-var releaseVersion = packageJson.version
+var releaseVersion = pkg.version
 var env = (process.env.NODE_ENV || 'development').toLowerCase()
 var useAutoStoreData = process.env.USE_AUTO_STORE_DATA || config.useAutoStoreData
 var useCookieSessionStore = process.env.USE_COOKIE_SESSION_STORE || config.useCookieSessionStore
@@ -113,6 +113,7 @@ app.locals.useCookieSessionStore = (useCookieSessionStore === 'true')
 app.locals.cookieText = config.cookieText
 app.locals.releaseVersion = 'v' + releaseVersion
 app.locals.serviceName = config.serviceName
+app.locals.serviceSlug = pkg.name
 app.locals.urStudy = urStudy
 // extensionConfig sets up variables used to add the scripts and stylesheets to each page.
 app.locals.extensionConfig = extensions.getAppConfig()


### PR DESCRIPTION
- Changes service name to ‘Apply for teacher training’ (for user research)
- Makes the service URL (slug) configurable
- Updates emails to include service name/slug variables