### PR TITLE
Work history bugs

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -72,6 +72,8 @@ module.exports = (env) => {
     if (obj) {
       const arr = []
       for (const [key, value] of Object.entries(obj)) {
+        console.log('key', key)
+        console.log('value', value)
         value.id = key
         arr.push(value)
       }

--- a/app/filters.js
+++ b/app/filters.js
@@ -72,8 +72,6 @@ module.exports = (env) => {
     if (obj) {
       const arr = []
       for (const [key, value] of Object.entries(obj)) {
-        console.log('key', key)
-        console.log('value', value)
         value.id = key
         arr.push(value)
       }

--- a/app/views/_includes/item/gap.njk
+++ b/app/views/_includes/item/gap.njk
@@ -2,8 +2,8 @@
 
 {% set itemStart = item["start-date"] %}
 {% set itemEnd = item["end-date"] if item["end-date"] else "now" %}
-{% set itemStartEpoch = itemStart | date("x") %}
-{% set itemEndEpoch = itemEnd | date("x") %}
+{% set itemStartEpoch = itemStart | date("x") | int %}
+{% set itemEndEpoch = itemEnd | date("x") | int %}
 {% set itemDuration = itemEndEpoch - itemStartEpoch %}
 
 {% set gapText -%}

--- a/app/views/_includes/review/work-history.njk
+++ b/app/views/_includes/review/work-history.njk
@@ -6,7 +6,7 @@
   | selectattr("id")
 %}
 
-{% set hasHistory = workHistory | toArray | length >= 1 %}
+{% set hasHistory = workHistory | length >= 1 %}
 {% set hasMissing = applicationValue(["work-history", "length"]) == "none" and not hasHistory %}
 {% set hasAutomaticGaps = data.flags.automatic_gaps == true %}
 

--- a/app/views/_includes/review/work-history.njk
+++ b/app/views/_includes/review/work-history.njk
@@ -23,18 +23,18 @@
     {% if hasAutomaticGaps %}
       {# periodStart = Earliest date in required work history period #}
       {% set periodStart = "now" | date | replace("2019", "2014") %}
-      {% set periodStartEpoch = periodStart | date("x") %}
+      {% set periodStartEpoch = periodStart | date("x") | int %}
 
       {# firstStart = Start date of first item in work history #}
       {% set firstStart = item["start-date"] %}
-      {% set firstStartEpoch = firstStart | date("x") %}
+      {% set firstStartEpoch = firstStart | date("x") | int %}
 
       {% if loop.first and firstStartEpoch > periodStartEpoch %}
         {# Unexplained gap (prior to work history commencing) #}
         {% set itemStart = periodStart %}
-        {% set itemStartEpoch = itemStart | date("x") %}
+        {% set itemStartEpoch = itemStart | date("x") | int %}
         {% set itemEnd = firstStart %}
-        {% set itemEndEpoch = itemEnd | date("x") %}
+        {% set itemEndEpoch = itemEnd | date("x") | int %}
         {% set itemDuration = itemEndEpoch - itemStartEpoch %}
         {{ appSummaryCard({
           classes: "govuk-!-margin-bottom-6",
@@ -52,9 +52,9 @@
 
     {% if item.category == "gap" %}
       {% set itemStart = item["start-date"] %}
-      {% set itemStartEpoch = itemStart | date("x") %}
+      {% set itemStartEpoch = itemStart | date("x") | int %}
       {% set itemEnd = item["end-date"] %}
-      {% set itemEndEpoch = itemEnd | date("x") %}
+      {% set itemEndEpoch = itemEnd | date("x") | int %}
       {% set itemDuration = itemEndEpoch - itemStartEpoch %}
       {{ appSummaryCard({
         classes: "govuk-!-margin-bottom-6",
@@ -87,9 +87,9 @@
       {# Unexplained gap (during work history) #}
       {% set nextItem = workHistory[loop.index] %}
       {% set itemStart = item["end-date"] %}
-      {% set itemStartEpoch = itemStart | date("x") %}
+      {% set itemStartEpoch = itemStart | date("x") | int %}
       {% set itemEnd = nextItem["start-date"] if nextItem else "now" %}
-      {% set itemEndEpoch = itemEnd | date("x") %}
+      {% set itemEndEpoch = itemEnd | date("x") | int %}
       {% set itemDuration = itemEndEpoch - itemStartEpoch %}
       {% if itemEndEpoch > itemStartEpoch and itemDuration > 2678400000 %}
         {{ appSummaryCard({


### PR DESCRIPTION
- Don’t use `toArray` filter twice (causes `item.id` to return array index instead of ID)
- Ensure UNIX epochs are returned as numbers before comparing