### PR TITLE
Spike: Checkboxes to mark sections as completed

### DIFF
--- a/app/views/_includes/review/degrees.njk
+++ b/app/views/_includes/review/degrees.njk
@@ -1,5 +1,9 @@
-{% set degrees = applicationValue(["degree"]) | toArray %}
 {% set applicationPath = "/application/" + applicationId %}
+{% set degrees = applicationValue(["degree"])
+  | toArray
+  | selectattr("id")
+%}
+
 {% if degrees.length >= 1 %}
   {% for item in degrees %}
     {% set degreeHtml %}

--- a/app/views/_includes/review/other-qualifications.njk
+++ b/app/views/_includes/review/other-qualifications.njk
@@ -1,5 +1,9 @@
 {% set applicationPath = "/application/" + applicationId %}
-{% set qualifications = applicationValue("other-qualifications") | toArray %}
+{% set qualifications = applicationValue(["other-qualifications"])
+  | toArray
+  | selectattr("id")
+%}
+
 {% if qualifications.length >= 1 %}
   {% for item in qualifications %}
     {% set qualificationHtml %}

--- a/app/views/_includes/review/school-experience.njk
+++ b/app/views/_includes/review/school-experience.njk
@@ -1,5 +1,5 @@
 {% set applicationPath = "/application/" + applicationId %}
-{% set schoolExperience = applicationValue("school-experience")
+{% set schoolExperience = applicationValue(["school-experience"])
   | toArray
   | sort(attribute="start-date")
   | selectattr("id")

--- a/app/views/application/degree/review.njk
+++ b/app/views/application/degree/review.njk
@@ -1,8 +1,9 @@
-{% extends "_content-wide.njk" %}
+{% extends "_form-wide.njk" %}
 
 {% set applicationPath = "/application/" + applicationId %}
-{% set referrer = applicationPath + "/degree/review" %}
+{% set formaction = applicationPath %}
 {% set title = "Degree" %}
+{% set referrer = applicationPath + "/degree/review" %}
 {% set review = true %}
 
 {% block pageNavigation %}
@@ -21,8 +22,14 @@
     href: applicationPath + "/degree/add"
   }) }}
 
+  {{ govukCheckboxes({
+    items: [{
+      value: "true",
+      text: "I have completed this section"
+    }]
+  } | decorateApplicationAttributes(["completed", "degree"])) }}
+
   {{ govukButton({
-    text: "Continue",
-    href: applicationPath
+    text: "Continue"
   }) }}
 {% endblock %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -51,12 +51,12 @@
       text: "Work history",
       href: applicationPath + "/work-history" + ("/review" if applicationValue("work-history")),
       id: "work-history",
-      completed: applicationValue("work-history")
+      completed: applicationValue(["completed", "work-history"])
     }, {
       text: "School experience and volunteering with young people",
       href: applicationPath + "/school-experience" + ("/review" if applicationValue("school-experience")),
       id: "school-experience",
-      completed: applicationValue("school-experience")
+      completed: applicationValue(["completed", "school-experience"])
     }]
   }) }}
 
@@ -67,7 +67,7 @@
       text: "Degree",
       href: applicationPath + "/degree" + ("/review" if applicationValue(["degree"]) else "/add"),
       id: "degree",
-      completed: applicationValue(["degree"])
+      completed: applicationValue(["completed", "degree"])
     }, {
       text: "Maths GCSE or equivalent",
       href: applicationPath + "/gcse/maths" + ("/review" if applicationValue(["gcse", "maths"])),
@@ -87,7 +87,7 @@
       text: "Other relevant academic and non-academic qualifications",
       href: applicationPath + "/other-qualifications" + ("/review" if applicationValue(["other-qualifications"]) else "/add"),
       id: "other-qualifications",
-      completed: applicationValue(["other-qualifications"])
+      completed: applicationValue(["completed", "other-qualifications"])
     }]
   }) }}
 

--- a/app/views/application/other-qualifications/review.njk
+++ b/app/views/application/other-qualifications/review.njk
@@ -1,8 +1,9 @@
-{% extends "_content-wide.njk" %}
+{% extends "_form-wide.njk" %}
 
 {% set applicationPath = "/application/" + applicationId %}
-{% set referrer = applicationPath + "/other-qualifications/review" %}
+{% set formaction = applicationPath %}
 {% set title = "Other relevant qualifications" %}
+{% set referrer = applicationPath + "/other-qualifications/review" %}
 {% set review = true %}
 
 {% block pageNavigation %}
@@ -20,8 +21,14 @@
     href: applicationPath + "/other-qualifications/add"
   }) }}
 
+  {{ govukCheckboxes({
+    items: [{
+      value: "true",
+      text: "I have completed this section"
+    }]
+  } | decorateApplicationAttributes(["completed", "other-qualifications"])) }}
+
   {{ govukButton({
-    text: "Continue",
-    href: applicationPath
+    text: "Continue"
   }) }}
 {% endblock %}

--- a/app/views/application/school-experience/review.njk
+++ b/app/views/application/school-experience/review.njk
@@ -1,6 +1,7 @@
-{% extends "_content-wide.njk" %}
+{% extends "_form-wide.njk" %}
 
 {% set applicationPath = "/application/" + applicationId %}
+{% set formaction = applicationPath %}
 {% set title = "School experience and volunteering with young people" %}
 {% set referrer = applicationPath + "/school-experience/review" %}
 {% set review = true %}
@@ -22,9 +23,16 @@
       href: applicationPath + "/school-experience/add/role?referrer=" + referrer,
       classes: "govuk-button--secondary"
     }) }}
+
+    {{ govukCheckboxes({
+      items: [{
+        value: "true",
+        text: "I have completed this section"
+      }]
+    } | decorateApplicationAttributes(["completed", "school-experience"])) }}
   {% endif %}
+
   {{ govukButton({
-    text: "Continue",
-    href: applicationPath
+    text: "Continue"
   }) }}
 {% endblock %}

--- a/app/views/application/work-history/review.njk
+++ b/app/views/application/work-history/review.njk
@@ -1,8 +1,9 @@
-{% extends "_content-wide.njk" %}
+{% extends "_form-wide.njk" %}
 
 {% set applicationPath = "/application/" + applicationId %}
-{% set referrer = applicationPath + "/work-history/review" %}
+{% set formaction = applicationPath %}
 {% set title = "Work history" %}
+{% set referrer = applicationPath + "/work-history/review" %}
 {% set review = true %}
 
 {% block pageNavigation %}
@@ -22,8 +23,14 @@
     }) }}
   {% endif %}
 
+  {{ govukCheckboxes({
+    items: [{
+      value: "true",
+      text: "I have completed this section"
+    }]
+  } | decorateApplicationAttributes(["completed", "work-history"])) }}
+
   {{ govukButton({
-    text: "Continue",
-    href: applicationPath
+    text: "Continue"
   }) }}
 {% endblock %}


### PR DESCRIPTION
- Adds a checkbox (’I have completed this section’) to the following section review pages:
  - Work history
  - School experience
  - Degrees
  - Other relevant qualifications

## Example (work history)

<img width="1024" alt="Completed checkbox on work history page" src="https://user-images.githubusercontent.com/813383/65683128-66ea0c00-e054-11e9-9255-2dfe854ae358.png">

## Open questions

- Are we happy with this label and placement of this option?
- Do we want to show this option if you have provided an explanation for not having worked, or not having any school experience (shown below)?
- Do we want to use this functionality on the references review page?

![Checkbox shown when not added work history](https://user-images.githubusercontent.com/813383/65683409-0effd500-e055-11e9-82c6-0e5450a2a66f.png)
![Checkbox shown when indicted no school experience](https://user-images.githubusercontent.com/813383/65683414-11fac580-e055-11e9-8c94-c7b88c85bdca.png)

