### PR TITLE
Various fixes and improvements for work and volunteering

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -7,11 +7,9 @@ $govuk-global-styles: true;
 
 // Components that aren’t in Frontend
 @import "components/autocomplete";
-@import "components/caption";
 @import "components/course";
 @import "components/cookie-banner";
 @import "components/footer";
-@import "components/heading";
 @import "components/hidden-link";
 @import "components/icon";
 @import "components/related";

--- a/app/assets/sass/components/_caption.scss
+++ b/app/assets/sass/components/_caption.scss
@@ -1,5 +1,0 @@
-.app-caption-s {
-  @include govuk-font($size: 19);
-  display: block;
-  color: $govuk-secondary-text-colour;
-}

--- a/app/assets/sass/components/_heading.scss
+++ b/app/assets/sass/components/_heading.scss
@@ -1,7 +1,0 @@
-.app-heading-xs {
-  @include govuk-text-colour;
-  @include govuk-font($weight: bold, $size: 16);
-  display: block;
-  margin-top: 0;
-  @include govuk-responsive-margin(4, "bottom");
-}

--- a/app/assets/sass/components/_summary-card.scss
+++ b/app/assets/sass/components/_summary-card.scss
@@ -9,11 +9,23 @@
     @include govuk-media-query($from: desktop) {
       display: flex;
       justify-content: space-between;
+      align-items: start;
     }
   }
 
   .app-summary-card__title {
     @include govuk-font($size: 19);
+    margin-top: 0;
+    margin-bottom: govuk-spacing(2);
+
+    @include govuk-media-query($from: desktop) {
+      margin: 0;
+    }
+  }
+
+  .app-summary-card__meta {
+    @include govuk-font($size: 16);
+    display: block;
     margin: 0;
   }
 
@@ -28,10 +40,12 @@
   }
 
   .app-summary-card__actions-list-item {
-    display: inline;
-    margin-right:  govuk-spacing(2);
-    padding-right: govuk-spacing(2);
+    display: block;
     white-space: nowrap;
+
+    @include govuk-media-query($from: desktop) {
+      text-align: right;
+    }
   }
 
   .app-summary-card__actions-list-item:last-child {

--- a/app/assets/sass/components/_table.scss
+++ b/app/assets/sass/components/_table.scss
@@ -1,7 +1,3 @@
-.app-table__row--muted {
-  background-color: govuk-colour("light-grey");
-}
-
 .app-table__cell--action {
   padding-right: govuk-spacing(2) !important;
   text-align: right;

--- a/app/routes/delete.js
+++ b/app/routes/delete.js
@@ -37,7 +37,7 @@ module.exports = router => {
 
       case 'work-history': {
         parent = item.role ? item.role : 'Work history'
-        type = item.role ? 'job' : 'gap'
+        type = item.role ? 'job' : 'gap entry'
         break
       }
     }

--- a/app/views/_components/icon/template.njk
+++ b/app/views/_components/icon/template.njk
@@ -1,4 +1,4 @@
-<svg class="app-icon{%- if params.classes %} {{ params.classes }}{% endif %}" xmlns="http://www.w3.org/2000/svg" width="{{ params.size | default(16) }}" height="{{ params.size | default(16) }}" viewBox="0 0 200 200" focusable="false" fill="currentColor"{%- if params.label %} aria-label="{{ params.label }}"{% endif %}{%- if params.hidden %} aria-hidden="true"{% endif %}>
+<svg class="app-icon{%- if params.classes %} {{ params.classes }}{% endif %}" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 200 200" focusable="false" fill="currentColor"{%- if params.label %} aria-label="{{ params.label }}"{% endif %}{%- if params.hidden %} aria-hidden="true"{% endif %}>
 {% if params.icon == "tick" %}
   <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"/>
 {% endif %}

--- a/app/views/_includes/item/job.njk
+++ b/app/views/_includes/item/job.njk
@@ -10,17 +10,6 @@
   {% endif %}
 {%- endset %}
 
-{% set descriptionHtml -%}
-  <p>{{ item.description | nl2br | safe }}</p>
-  {%- if item["worked-with-children"] == "Yes" %}
-  <p>{{ appIcon({
-      classes: "govuk-!-margin-right-1",
-      icon: "tick",
-      hidden: true
-    }) }} This role involved working with children.</p>
-  {% endif %}
-{%- endset %}
-
 {% set datesText %}
   {{ itemStart | date("MMMM yyyy") }} - {{ itemEnd | date("MMMM yyyy") if item["end-date"] else "Present" }}
 {% endset %}
@@ -61,7 +50,7 @@
       text: "Description"
     },
     value: {
-      text: descriptionHtml | safe
+      text: (item.description | nl2br | safe) or "Not entered"
     },
     actions: {
       items: [{

--- a/app/views/_includes/item/role.njk
+++ b/app/views/_includes/item/role.njk
@@ -3,8 +3,11 @@
 {% set itemStart = item["start-date"] %}
 {% set itemEnd = item["end-date"] if item["end-date"] else "now" %}
 
-{% set datesText %}
-  {{ itemStart | date("d MMMM yyyy") }} - {{ itemEnd | date("d MMMM yyyy") if item["end-date"] else "Present" }}
+{% set datesHtml -%}
+  {{- itemStart | date("MMMM yyyy") }} - {{ itemEnd | date("MMMM yyyy") if item["end-date"] else "Present" }}
+  {%- if item["time-commitment"] -%}
+    <br>{{ item["time-commitment"] | nl2br | safe }}
+  {%- endif %}
 {% endset %}
 
 {% set changeHref = applicationPath + "/school-experience/role/" + item.id + "?referrer=" + referrer %}
@@ -40,10 +43,10 @@
     } if review == true
   }, {
     key: {
-      text: "Dates"
+      text: "Time commitment"
     },
     value: {
-      text: datesText
+      text: datesHtml | nl2br | safe
     },
     actions: {
       items: [{

--- a/app/views/_includes/review/school-experience.njk
+++ b/app/views/_includes/review/school-experience.njk
@@ -10,10 +10,20 @@
     {% set roleHtml %}
       {% include "_includes/item/role.njk" %}
     {% endset %}
+    {% set titleHtml %}
+      {{ item.role }}
+      {%- if item["worked-with-children"] == "Yes" %}
+      <span class="app-summary-card__meta">{{ appIcon({
+          classes: "govuk-!-margin-right-1",
+          icon: "tick",
+          hidden: true
+        }) }} This role involved working with children</span>
+      {%- endif %}
+    {% endset %}
     {{ appSummaryCard({
       classes: "govuk-!-margin-bottom-6",
       headingLevel: 3,
-      titleText: item.role,
+      titleHtml: titleHtml,
       actions: {
         items: [{
           href: applicationPath + "/school-experience/" + item.id + "/delete?referrer=" + referrer,

--- a/app/views/_includes/review/work-history.njk
+++ b/app/views/_includes/review/work-history.njk
@@ -69,10 +69,20 @@
         html: gapHtml
       }) }}
     {% else %}
+      {% set titleHtml %}
+        {{ item.role }}
+        {%- if item["worked-with-children"] == "Yes" %}
+        <span class="app-summary-card__meta">{{ appIcon({
+            classes: "govuk-!-margin-right-1",
+            icon: "tick",
+            hidden: true
+          }) }} This role involved working with children</span>
+        {%- endif %}
+      {% endset %}
       {{ appSummaryCard({
         classes: "govuk-!-margin-bottom-6",
         headingLevel: 3,
-        titleText: item.role,
+        titleHtml: titleHtml,
         actions: {
           items: [{
             href: applicationPath + "/work-history/" + item.id + "/delete?referrer=" + referrer,
@@ -102,7 +112,7 @@
               text: "Please explain gap"
             }, {
               href: applicationPath + "/work-history/add/job?referrer="  + referrer,
-              text: "Add job"
+              text: "Add another job"
             }]
           } if review == true
         }) }}

--- a/app/views/application/school-experience/role.njk
+++ b/app/views/application/school-experience/role.njk
@@ -18,12 +18,13 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">Don’t include paid work in a school – enter these roles in ‘Work history’.</p>
-
   {{ govukInput({
     label: {
       text: "Your role",
       classes: "govuk-label--m"
+    },
+    hint: {
+      text: "Don’t include paid work in a school – enter these roles in ‘Work history’."
     }
   } | decorateApplicationAttributes(["school-experience", id, "role"])) }}
 
@@ -34,6 +35,22 @@
     }
   } | decorateApplicationAttributes(["school-experience", id, "org"])) }}
 
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: "Did this job involve working in a school or with children?",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    classes: "govuk-radios--inline",
+    items: [{
+      text: "Yes"
+    }, {
+      text: "No"
+    }]
+  } | decorateApplicationAttributes(["school-experience", id, "worked-with-children"])) }}
+
+  <h2 class="govuk-heading-m">Time commitment</h2>
   {% set startDate = applicationValue(["school-experience", id, "start-date"]) %}
   {% set endDate = applicationValue(["school-experience", id, "end-date"]) %}
 
@@ -41,19 +58,14 @@
     fieldset: {
       legend: {
         text: "Start date",
-        classes: "govuk-fieldset__legend--m"
+        classes: "govuk-fieldset__legend--s"
       }
     },
     hint: {
-      text: "For example, 27 3 2018"
+      text: "For example, 3 2018"
     },
     namePrefix: id + "-start-date",
     items: [{
-      label: "Day",
-      name: "day",
-      value: startDate | date("d"),
-      classes: "govuk-input--width-2"
-    }, {
       label: "Month",
       name: "month",
       value: startDate | date("L"),
@@ -70,19 +82,14 @@
     fieldset: {
       legend: {
         text: "End date (leave blank if this is your current role)",
-        classes: "govuk-fieldset__legend--m"
+        classes: "govuk-fieldset__legend--s"
       }
     },
     hint: {
-      text: "For example, 27 3 2019"
+      text: "For example, 3 2019"
     },
     namePrefix: id + "-end-date",
     items: [{
-      label: "Day",
-      name: "day",
-      value: endDate | date("d"),
-      classes: "govuk-input--width-2"
-    }, {
       label: "Month",
       name: "month",
       value: endDate | date("L"),
@@ -94,19 +101,18 @@
       classes: "govuk-input--width-4"
     }]
   } | decorateApplicationAttributes(["school-experience", id, "end-date"])) }}
-  {{ govukRadios({
-    fieldset: {
-      legend: {
-        text: "Did this job involve working in a school or with children?"
-      }
+
+  {{ govukCharacterCount({
+    label: {
+      text: "Enter details of the time commitment involved in this role",
+      classes: "govuk-label--s"
     },
-    classes: "govuk-radios--inline",
-    items: [{
-      text: "Yes"
-    }, {
-      text: "No"
-    }]
-  } | decorateApplicationAttributes(["work-history", id, "worked-with-children"])) }}
+    hint: {
+      text: "For example, ‘I volunteer every Friday morning’ or ‘I spent 1 day observing in this school’ or ‘I am a Scout Leader involved in activities throughout the year’"
+    },
+    maxwords: 150
+  } | decorateApplicationAttributes(["school-experience", id, "time-commitment"])) }}
+
   {{ govukButton({
     text: "Continue"
   }) }}

--- a/app/views/application/work-history/job.njk
+++ b/app/views/application/work-history/job.njk
@@ -18,8 +18,6 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">Don’t include voluntary or unpaid experience – we’ll ask you about this in ‘School experience and volunteering’.</li>
-
   {{ govukInput({
     label: {
       text: "Job title",
@@ -31,6 +29,9 @@
     label: {
       text: "Name of employer",
       classes: "govuk-label--m"
+    },
+    hint: {
+      text: "Don’t include voluntary or unpaid experience – we’ll ask you about this in ‘School experience and volunteering’."
     }
   } | decorateApplicationAttributes(["work-history", id, "org"])) }}
 


### PR DESCRIPTION
- Adds additional fields to volunteering role
- Moves indication for jobs/roles that involved working with children to summary card title
- Stacks and renames action links on gap card (Fixes #205)
- Removes deprecated app styles (`app-caption`, `app-heading` and `app-table__row--muted`)
- Remove day from role start and end dates