### PR TITLE
Update magic link email content

### DIFF
--- a/app/views/account/check-email.njk
+++ b/app/views/account/check-email.njk
@@ -5,4 +5,5 @@
 
 {% block primary %}
   <p class="govuk-body-l"><a class="app-hidden-link" href="/email/confirm-address/{{ action }}">We’ve sent you an email</a>. Click on the link to confirm your {{ "new " if action == "change-email-address" }}address and return to this service.</p>
+  <p class="govuk-body">If our email doesn’t arrive within 5 minutes, check your spam and trash folder, or <a href="/account/create-account">try again</a>.</p>
 {% endblock %}

--- a/app/views/email/confirm-address.njk
+++ b/app/views/email/confirm-address.njk
@@ -1,20 +1,27 @@
 {% extends "_email.njk" %}
 
-{% set title = "Please confirm your email address" %}
+{% if action == "create-account" %}
+  {% set title = "Please confirm your email address" %}
+{% elif action == "change-email-address" %}
+  {% set title = "Please confirm your new email address" %}
+{% else %}
+  {% set title = "Sign in to " + serviceName %}
+{% endif %}
 {% set to = data.account.email %}
 
 {% block content %}
-  <h1 class="govuk-heading-m">Please confirm your email address</h1>
   {% if action == "create-account" %}
-    <p>Click the link below to confirm your email address and go back to the <b>Apply for teacher training</b> service.</p>
+    <h1 class="govuk-heading-m">{{ title }}</h1>
+    <p>Click the link below to confirm your email address and go back to the <b>{{ serviceName }}</b> service.</p>
     <p><a href="/application/start">https://{{ serviceSlug }}.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
     <p>You will then be able to save and return to your application.</p>
-    <p>By signing in, you also agree to the <a href="#">terms and conditions</a> of the ‘{{ serviceName }}’ service.
+    <p>By signing in, you also agree to the <a href="#">terms and conditions</a> of the {{ serviceName }} service.
   {% elif action == "change-email-address" %}
-    <p>You have successfully changed the email address you use to sign in to the <b>{{ serviceName }}</b> service.</p>
-    <p>Click on the link below to return to the service.</p>
+    <h1 class="govuk-heading-m">{{ title }}</h1>
+    <p>Click the link below to confirm your new email address and go back to the <b>{{ serviceName }}</b> service.</p>
     <p><a href="/applications">https://{{ serviceSlug }}.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
   {% else %}
+    <h1 class="govuk-heading-m">{{ title }}</h1>
     <p>Click the link below to sign in to the <b>{{ serviceName }}</b> service.</p>
     <p><a href="/applications">https://{{ serviceSlug }}.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
   {% endif %}


### PR DESCRIPTION
Updates to magic link email content. See [Card 73](https://trello.com/c/xBMMWn5J). @laurahermionetennant92 to review.

## Create account

> ### Please confirm your email address
> Click the link below to confirm your email address and go back to the **Apply for teacher training** service.
>
> [[Link]](#)
>
> You will then be able to save and return to your application.
>
> By signing in, you also agree to the [terms and conditions](#) of the ‘Apply for teacher training’ service.

## Sign in

> ### Sign in to Apply for teacher training
>
> Click the link below to sign in to the **Apply for teacher training** service.
>
> [[Link]](#)

## Change email

> ### Please confirm your new email address
>
> Click the link below to confirm your new email address and go back to the **Apply for teacher training** service.
>
> [[Link]](#)