### PR TITLE
Add or continue

### DIFF
--- a/app/assets/javascripts/modules/clear-hidden.js
+++ b/app/assets/javascripts/modules/clear-hidden.js
@@ -23,7 +23,6 @@
         const inputs = form.querySelectorAll('input, textarea')
         for (const input of inputs) {
           const conditional = getClosest(input, '.govuk-radios__conditional') || getClosest(input, '.govuk-checkboxes__conditional')
-          console.log('conditional', conditional)
           if (conditional && conditional.id) {
             const controller = this.querySelector(`[aria-controls=${conditional.id}]`)
 

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -180,7 +180,7 @@ module.exports = {
           description: 'Taught Mathematics and Physics content covered in the Scottish National 5, the Higher and the Advanced Higher curricula. Assessed, graded and tracked individual’s progress in the above-mentioned subjects. Guided students to perform better in the exam by offering them mock exams and giving adequate scientific feedback.',
           'worked-with-children': 'Yes',
           'start-date': '2017-09-01',
-          'end-date': false
+          'end-date': 'now'
         }
       },
       'school-experience': {

--- a/app/routes/application/school-experience.js
+++ b/app/routes/application/school-experience.js
@@ -23,34 +23,39 @@ module.exports = router => {
 
   // Render role page
   router.get('/application/:applicationId/school-experience/role/:id', (req, res) => {
+    const applicationId = req.params.applicationId
     const id = req.params.id
-    const queryString = querystring.stringify(req.query)
     const referrer = req.query.referrer
 
     res.render('application/school-experience/role', {
       referrer,
-      formaction: `/application/${req.params.applicationId}/school-experience/update/role/${id}?${queryString}`,
-      id,
-      start: `${req.query.start}`,
-      end: `${req.query.end}`
+      formaction: `/application/${applicationId}/school-experience/review?update=${id}`,
+      id
     })
   })
 
-  // Convert individual date components into ISO 8601 date strings
-  router.post('/application/:applicationId/school-experience/update/role/:id', (req, res) => {
-    const id = req.params.id
+  // Convert individual date components into single ISO 8601 date string before
+  // proceeding to next page (reviewing all or adding another)
+  router.post('/application/:applicationId/school-experience/:next(review|add)', (req, res) => {
     const applicationId = req.params.applicationId
-    const applicationData = req.session.data.applications[applicationId]['school-experience'][id]
+    const next = req.params.next
 
-    utils.saveIsoDate(req, applicationData, id)
+    const id = req.query.update
+    const applicationData = utils.applicationData(req)
+    const schoolExperience = applicationData['school-experience']
+    utils.saveIsoDate(req, schoolExperience, id)
 
-    res.redirect(req.query.referrer || `/application/${applicationId}/school-experience/review`)
+    if (next === 'review') {
+      res.redirect(`/application/${applicationId}/school-experience/review`)
+    } else {
+      res.redirect(`/application/${applicationId}/school-experience/add/role`)
+    }
   })
 
   // School-experience completed answer branching
   router.post('/application/:applicationId/school-experience/answer', (req, res) => {
     const applicationId = req.params.applicationId
-    const applicationData = req.session.data.applications[applicationId]
+    const applicationData = utils.applicationData(req)
     const attained = applicationData['school-experience'].attained
 
     if (attained === 'false') {

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -17,6 +17,11 @@ const getQueryString = (req) => {
 }
 
 const saveIsoDate = (req, data, id) => {
+  // If no ID, we won’t have any dates to convert
+  if (!id) {
+    return
+  }
+
   // Create ISO 8601 start date
   const startDay = (req.body[`${id}-start-date-day`] || '1').padStart(2, '0')
   const startMonth = (req.body[`${id}-start-date-month`]).padStart(2, '0')

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -21,20 +21,20 @@ const saveIsoDate = (req, data, id) => {
   const startDay = (req.body[`${id}-start-date-day`] || '1').padStart(2, '0')
   const startMonth = (req.body[`${id}-start-date-month`]).padStart(2, '0')
   const startYear = req.body[`${id}-start-date-year`]
-  data['start-date'] = false
+  data[id]['start-date'] = false
 
   if (startMonth && startYear) {
-    data['start-date'] = `${startYear}-${startMonth}-${startDay}`
+    data[id]['start-date'] = `${startYear}-${startMonth}-${startDay}`
   }
 
   // Create ISO 8601 end date
   const endDay = (req.body[`${id}-end-date-day`] || '1').padStart(2, '0')
   const endMonth = (req.body[`${id}-end-date-month`]).padStart(2, '0')
   const endYear = req.body[`${id}-end-date-year`]
-  data['end-date'] = false
+  data[id]['end-date'] = 'now' // No date indicates today
 
   if (endMonth && endYear) {
-    data['end-date'] = `${endYear}-${endMonth}-${endDay}`
+    data[id]['end-date'] = `${endYear}-${endMonth}-${endDay}`
   }
 }
 

--- a/app/views/_components/footer/template.njk
+++ b/app/views/_components/footer/template.njk
@@ -1,8 +1,8 @@
 {#
   Extends and modifies the footer component from GOV.UK Frontend by:
-   * Removing licensing information
-   * Providing params.meta.title (shows params.meta.visuallyHiddenTitle if not set)
-   * Moving meta.text/meta.html above meta.items
+    * Removing licensing information
+    * Providing params.meta.title (shows params.meta.visuallyHiddenTitle if not set)
+    * Moving meta.text/meta.html above meta.items
 #}
 <footer class="govuk-footer {{ params.classes if params.classes }}" role="contentinfo"
         {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>

--- a/app/views/_content-wide.njk
+++ b/app/views/_content-wide.njk
@@ -3,14 +3,10 @@
 {% block content %}
   {% if title %}
     <h1 class="govuk-heading-xl">
-    {% if parent %}
-      <span class="govuk-caption-xl">{{ parent }}</span> {{ title }}
-    {% else %}
+      {% if parent %}<span class="govuk-caption-xl">{{ parent }}</span>{% endif %}
       {{ title | safe }}
-    {% endif %}
     </h1>
   {% endif %}
-
   {% block primary %}
   {% endblock %}
 {% endblock %}

--- a/app/views/_content.njk
+++ b/app/views/_content.njk
@@ -1,25 +1,23 @@
 {% extends "_layout.njk" %}
 
 {% block content %}
-{% if title %}
-  <h1 class="govuk-heading-xl">
-  {% if parent %}
-    <span class="govuk-caption-xl">{{ parent }}</span> {{ title }}
-  {% else %}
-    {{ title | safe }}
+  {% if title %}
+    <h1 class="govuk-heading-xl">
+      {% if parent %}<span class="govuk-caption-xl">{{ parent }}</span>{% endif %}
+      {{ title | safe }}
+    </h1>
   {% endif %}
-  </h1>
-{% endif %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    {% block primary %}
-    {% endblock %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% block primary %}
+      {% endblock %}
+    </div>
+    {% if hasSecondary %}
+    <div class="govuk-grid-column-one-third">
+      {% block secondary %}
+      {% endblock %}
+    </div>
+    {% endif %}
   </div>
-  {% if hasSecondary %}
-  <div class="govuk-grid-column-one-third">
-    {% block secondary %}
-    {% endblock %}
-  </div>
-  {% endif %}
-</div>
 {% endblock %}

--- a/app/views/_form-wide.njk
+++ b/app/views/_form-wide.njk
@@ -1,23 +1,20 @@
 {% extends "_layout.njk" %}
 
 {% block content %}
-  <form action="{{ formaction | default('#') }}" method="post">
+<form action="{{ formaction | default('#') }}" method="post">
   {% set legendHtml %}
-    {% if parent %}
-      <span class="govuk-caption-xl">{{ parent }}</span> {{ title }}
-    {% else %}
-      {{ title | safe }}
-    {% endif %}
+    {% if parent %}<span class="govuk-caption-xl">{{ parent }}</span>{% endif %}
+    {{ title | safe }}
   {% endset %}
   {% call govukFieldset({
     legend: {
       html: legendHtml,
-      classes: "govuk-fieldset__legend--xl",
+      classes: "govuk-fieldset__legend--xl govuk-!-margin-bottom-8",
       isPageHeading: true
     }
   }) %}
     {% block primary %}
     {% endblock %}
   {% endcall %}
-  </form>
+</form>
 {% endblock %}

--- a/app/views/_form.njk
+++ b/app/views/_form.njk
@@ -3,12 +3,18 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    {% if parent %}
-      <span class="govuk-caption-xl">{{ parent }}</span>
-    {% endif %}
-    <h1 class="govuk-heading-xl">{{ title | safe }}</h1>
     <form action="{{ formaction | default('#') }}" method="post">
-    {% call govukFieldset() %}
+    {% set legendHtml %}
+      {% if parent %}<span class="govuk-caption-xl">{{ parent }}</span>{% endif %}
+      {{ title | safe }}
+    {% endset %}
+    {% call govukFieldset({
+      legend: {
+        html: legendHtml,
+        classes: "govuk-fieldset__legend--xl govuk-!-margin-bottom-8",
+        isPageHeading: true
+      }
+    }) %}
       {% block primary %}{% endblock %}
     {% endcall %}
     </form>

--- a/app/views/_includes/item/gap.njk
+++ b/app/views/_includes/item/gap.njk
@@ -1,7 +1,7 @@
 {% set applicationPath = "/application/" + applicationId %}
 
 {% set itemStart = item["start-date"] %}
-{% set itemEnd = item["end-date"] if item["end-date"] else "now" %}
+{% set itemEnd = item["end-date"] %}
 {% set itemStartEpoch = itemStart | date("x") | int %}
 {% set itemEndEpoch = itemEnd | date("x") | int %}
 {% set itemDuration = itemEndEpoch - itemStartEpoch %}
@@ -11,7 +11,7 @@
 {%- endset %}
 
 {% set datesText %}
-  {{ itemStart | date("MMMM yyyy") }} - {{ itemEnd | date("MMMM yyyy") if item["end-date"] else "Present" }}
+  {{ itemStart | date("MMMM yyyy") }} - {{ itemEnd | date("MMMM yyyy") if item["end-date"] != "now" else "Present" }}
 {% endset %}
 
 {% set changeHref = applicationPath + "/work-history/gap/" + item.id + "?referrer=" + referrer %}

--- a/app/views/_includes/item/job.njk
+++ b/app/views/_includes/item/job.njk
@@ -1,8 +1,5 @@
 {% set applicationPath = "/application/" + applicationId %}
 
-{% set itemStart = item["start-date"] %}
-{% set itemEnd = item["end-date"] if item["end-date"] else "now" %}
-
 {% set jobHtml -%}
   {{ item.role }}
   {%- if item.org %}
@@ -11,7 +8,7 @@
 {%- endset %}
 
 {% set datesText %}
-  {{ itemStart | date("MMMM yyyy") }} - {{ itemEnd | date("MMMM yyyy") if item["end-date"] else "Present" }}
+  {{ item["start-date"] | date("MMMM yyyy") }} - {{ item["end-date"] | date("MMMM yyyy") if item["end-date"] != "now" else "Present" }}
 {% endset %}
 
 {% set changeHref = applicationPath + "/work-history/job/" + item.id + "?referrer=" + referrer %}

--- a/app/views/_includes/item/role.njk
+++ b/app/views/_includes/item/role.njk
@@ -1,10 +1,7 @@
 {% set applicationPath = "/application/" + applicationId %}
 
-{% set itemStart = item["start-date"] %}
-{% set itemEnd = item["end-date"] if item["end-date"] else "now" %}
-
 {% set datesHtml -%}
-  {{- itemStart | date("MMMM yyyy") }} - {{ itemEnd | date("MMMM yyyy") if item["end-date"] else "Present" }}
+  {{- item["start-date"] | date("MMMM yyyy") }} - {{ item["end-date"] | date("MMMM yyyy") if item["end-date"] != "now" else "Present" }}
   {%- if item["time-commitment"] -%}
     <br>{{ item["time-commitment"] | nl2br | safe }}
   {%- endif %}

--- a/app/views/_includes/review/degrees.njk
+++ b/app/views/_includes/review/degrees.njk
@@ -1,10 +1,8 @@
 {% set applicationPath = "/application/" + applicationId %}
-{% set degrees = applicationValue(["degree"])
-  | toArray
-  | selectattr("id")
-%}
+{% set degrees = applicationValue(["degrees"]) %}
 
-{% if degrees.length >= 1 %}
+{% if degrees %}
+  {% set degrees = degrees | toArray | selectattr("id") %}
   {% for item in degrees %}
     {% set degreeHtml %}
       {% include "_includes/item/degree.njk" %}

--- a/app/views/_includes/review/other-qualifications.njk
+++ b/app/views/_includes/review/other-qualifications.njk
@@ -1,10 +1,8 @@
 {% set applicationPath = "/application/" + applicationId %}
-{% set qualifications = applicationValue(["other-qualifications"])
-  | toArray
-  | selectattr("id")
-%}
+{% set qualifications = applicationValue(["other-qualifications"]) %}
 
-{% if qualifications.length >= 1 %}
+{% if qualifications %}
+  {% set qualifications = qualifications | toArray | selectattr("id") %}
   {% for item in qualifications %}
     {% set qualificationHtml %}
       {% include "_includes/item/other-qualification.njk" %}

--- a/app/views/_includes/review/references.njk
+++ b/app/views/_includes/review/references.njk
@@ -1,7 +1,9 @@
 {% set applicationPath = "/application/" + applicationId %}
-{% set references = applicationValue("referees") | toArray %}
-{% if references.length >= 1 %}
+{% set references = applicationValue(["referees"]) %}
+
+{% if references %}
   <p class="govuk-body">We’ll contact your referees after you submit your application. We’ll let you know if they don’t supply a reference.</p>
+  {% set references = references | toArray %}
   {% for item in references %}
     {% set refereeHtml %}
       {% include "_includes/item/reference.njk" %}

--- a/app/views/_includes/review/school-experience.njk
+++ b/app/views/_includes/review/school-experience.njk
@@ -1,12 +1,9 @@
 {% set applicationPath = "/application/" + applicationId %}
-{% set schoolExperience = applicationValue(["school-experience"])
-  | toArray
-  | sort(attribute="start-date")
-  | selectattr("id")
-%}
+{% set schoolExperience = applicationValue(["school-experience"]) %}
 
-{% if schoolExperience.length >= 1 %}
-  {% for item in schoolExperience %}
+{% if schoolExperience %}
+  {% set roles = schoolExperience | toArray | selectattr("id") | sort(attribute="start-date") %}
+  {% for item in roles %}
     {% set roleHtml %}
       {% include "_includes/item/role.njk" %}
     {% endset %}

--- a/app/views/_includes/review/work-history.njk
+++ b/app/views/_includes/review/work-history.njk
@@ -111,7 +111,7 @@
               href: applicationPath + "/work-history/add/gap?start=" + itemStart | date("yyyy-LL") + "&end=" + itemEnd | date("yyyy-LL") + "&referrer=" + referrer,
               text: "Please explain gap"
             }, {
-              href: applicationPath + "/work-history/add/job?referrer="  + referrer,
+              href: applicationPath + "/work-history/add/job?start=" + itemStart | date("yyyy-LL") + "&end=" + itemEnd | date("yyyy-LL") + "&referrer=" + referrer,
               text: "Add another job"
             }]
           } if review == true

--- a/app/views/_includes/review/work-history.njk
+++ b/app/views/_includes/review/work-history.njk
@@ -1,140 +1,160 @@
 {% set applicationPath = "/application/" + applicationId %}
+{% set workHistory = applicationValue(["work-history"]) %}
 
-{% set workHistory = applicationValue("work-history")
-  | toArray
-  | sort(attribute="start-date")
-  | selectattr("id")
-%}
+{% if workHistory %}
+  {% set history = workHistory | toArray | selectattr("id") | sort(attribute="start-date") %}
+  {% if history.length >= 1 %}
+    {% set hasAutomaticGaps = data.flags.automatic_gaps == true %}
+    {% for item in history %}
+      {% set jobHtml %}
+        {% include "_includes/item/job.njk" %}
+      {% endset %}
 
-{% set hasHistory = workHistory | length >= 1 %}
-{% set hasMissing = applicationValue(["work-history", "length"]) == "none" and not hasHistory %}
-{% set hasAutomaticGaps = data.flags.automatic_gaps == true %}
+      {% set gapHtml %}
+        {% include "_includes/item/gap.njk" %}
+      {% endset %}
 
-{% if hasHistory and not hasMissing %}
-  {% for item in workHistory %}
-    {% set jobHtml %}
-      {% include "_includes/item/job.njk" %}
-    {% endset %}
+      {% if hasAutomaticGaps %}
+        {# periodStart = Earliest date in required work history period #}
+        {% set periodStart = "now" | date | replace("2019", "2014") %}
+        {% set periodStartEpoch = periodStart | date("x") | int %}
 
-    {% set gapHtml %}
-      {% include "_includes/item/gap.njk" %}
-    {% endset %}
+        {# firstStart = Start date of first item in work history #}
+        {% set firstStart = item["start-date"] %}
+        {% set firstStartEpoch = firstStart | date("x") | int %}
 
-    {% if hasAutomaticGaps %}
-      {# periodStart = Earliest date in required work history period #}
-      {% set periodStart = "now" | date | replace("2019", "2014") %}
-      {% set periodStartEpoch = periodStart | date("x") | int %}
+        {% if loop.first and firstStartEpoch > periodStartEpoch %}
+          {# Unexplained gap (prior to work history commencing) #}
+          {% set itemStart = periodStart %}
+          {% set itemStartEpoch = itemStart | date("x") | int %}
+          {% set itemEnd = firstStart %}
+          {% set itemEndEpoch = itemEnd | date("x") | int %}
+          {% set itemDuration = itemEndEpoch - itemStartEpoch %}
+          {{ appSummaryCard({
+            classes: "govuk-!-margin-bottom-6",
+            headingLevel: 3,
+            titleText: "Unexplained gap (" + (itemDuration | duration) + ")",
+            actions: {
+              items: [{
+                href: applicationPath + "/work-history/add/gap?start=" + itemStart | date("yyyy-LL") + "&end=" + itemEnd | date("yyyy-LL") + "&referrer=" + referrer,
+                text: "Explain gap"
+              }]
+            } if review == true
+          }) }}
+        {% endif %}
+      {% endif %}
 
-      {# firstStart = Start date of first item in work history #}
-      {% set firstStart = item["start-date"] %}
-      {% set firstStartEpoch = firstStart | date("x") | int %}
-
-      {% if loop.first and firstStartEpoch > periodStartEpoch %}
-        {# Unexplained gap (prior to work history commencing) #}
-        {% set itemStart = periodStart %}
+      {% if item.category == "gap" %}
+        {% set itemStart = item["start-date"] %}
         {% set itemStartEpoch = itemStart | date("x") | int %}
-        {% set itemEnd = firstStart %}
+        {% set itemEnd = item["end-date"] %}
         {% set itemEndEpoch = itemEnd | date("x") | int %}
         {% set itemDuration = itemEndEpoch - itemStartEpoch %}
         {{ appSummaryCard({
           classes: "govuk-!-margin-bottom-6",
           headingLevel: 3,
-          titleText: "Unexplained gap (" + (itemDuration | duration) + ")",
+          titleText: "Gap (" + (itemDuration | duration) + ")",
           actions: {
             items: [{
-              href: applicationPath + "/work-history/add/gap?start=" + itemStart | date("yyyy-LL") + "&end=" + itemEnd | date("yyyy-LL") + "&referrer=" + referrer,
-              text: "Explain gap"
+              href: applicationPath + "/work-history/" + item.id + "/delete?referrer=" + referrer,
+              text: "Delete gap entry"
             }]
-          } if review == true
+          } if review == true,
+          html: gapHtml
         }) }}
-      {% endif %}
-    {% endif %}
-
-    {% if item.category == "gap" %}
-      {% set itemStart = item["start-date"] %}
-      {% set itemStartEpoch = itemStart | date("x") | int %}
-      {% set itemEnd = item["end-date"] %}
-      {% set itemEndEpoch = itemEnd | date("x") | int %}
-      {% set itemDuration = itemEndEpoch - itemStartEpoch %}
-      {{ appSummaryCard({
-        classes: "govuk-!-margin-bottom-6",
-        headingLevel: 3,
-        titleText: "Gap (" + (itemDuration | duration) + ")",
-        actions: {
-          items: [{
-            href: applicationPath + "/work-history/" + item.id + "/delete?referrer=" + referrer,
-            text: "Delete gap entry"
-          }]
-        } if review == true,
-        html: gapHtml
-      }) }}
-    {% else %}
-      {% set titleHtml %}
-        {{ item.role }}
-        {%- if item["worked-with-children"] == "Yes" %}
-        <span class="app-summary-card__meta">{{ appIcon({
-            classes: "govuk-!-margin-right-1",
-            icon: "tick",
-            hidden: true
-          }) }} This role involved working with children</span>
-        {%- endif %}
-      {% endset %}
-      {{ appSummaryCard({
-        classes: "govuk-!-margin-bottom-6",
-        headingLevel: 3,
-        titleHtml: titleHtml,
-        actions: {
-          items: [{
-            href: applicationPath + "/work-history/" + item.id + "/delete?referrer=" + referrer,
-            text: "Delete job"
-          }]
-        } if review == true,
-        html: jobHtml
-      }) }}
-    {% endif %}
-
-    {% if hasAutomaticGaps %}
-      {# Unexplained gap (during work history) #}
-      {% set nextItem = workHistory[loop.index] %}
-      {% set itemStart = item["end-date"] %}
-      {% set itemStartEpoch = itemStart | date("x") | int %}
-      {% set itemEnd = nextItem["start-date"] if nextItem else "now" %}
-      {% set itemEndEpoch = itemEnd | date("x") | int %}
-      {% set itemDuration = itemEndEpoch - itemStartEpoch %}
-      {% if itemEndEpoch > itemStartEpoch and itemDuration > 2678400000 %}
+      {% else %}
+        {% set titleHtml %}
+          {{ item.role }}
+          {%- if item["worked-with-children"] == "Yes" %}
+          <span class="app-summary-card__meta">{{ appIcon({
+              classes: "govuk-!-margin-right-1",
+              icon: "tick",
+              hidden: true
+            }) }} This role involved working with children</span>
+          {%- endif %}
+        {% endset %}
         {{ appSummaryCard({
           classes: "govuk-!-margin-bottom-6",
           headingLevel: 3,
-          titleText: "You have a gap in your work history (" + (itemDuration | duration) + ")",
+          titleHtml: titleHtml,
           actions: {
             items: [{
-              href: applicationPath + "/work-history/add/gap?start=" + itemStart | date("yyyy-LL") + "&end=" + itemEnd | date("yyyy-LL") + "&referrer=" + referrer,
-              text: "Please explain gap"
-            }, {
-              href: applicationPath + "/work-history/add/job?start=" + itemStart | date("yyyy-LL") + "&end=" + itemEnd | date("yyyy-LL") + "&referrer=" + referrer,
-              text: "Add another job"
+              href: applicationPath + "/work-history/" + item.id + "/delete?referrer=" + referrer,
+              text: "Delete job"
             }]
-          } if review == true
+          } if review == true,
+          html: jobHtml
         }) }}
       {% endif %}
+
+      {% if hasAutomaticGaps %}
+        {# Unexplained gap (during work history) #}
+        {% set nextItem = history[loop.index] %}
+        {% set itemStart = item["end-date"] %}
+        {% set itemStartEpoch = itemStart | date("x") | int %}
+        {% set itemEnd = nextItem["start-date"] if nextItem else "now" %}
+        {% set itemEndEpoch = itemEnd | date("x") | int %}
+        {% set itemDuration = itemEndEpoch - itemStartEpoch %}
+        {% if itemEndEpoch > itemStartEpoch and itemDuration > 2678400000 %}
+          {{ appSummaryCard({
+            classes: "govuk-!-margin-bottom-6",
+            headingLevel: 3,
+            titleText: "You have a gap in your work history (" + (itemDuration | duration) + ")",
+            actions: {
+              items: [{
+                href: applicationPath + "/work-history/add/gap?start=" + itemStart | date("yyyy-LL") + "&end=" + itemEnd | date("yyyy-LL") + "&referrer=" + referrer,
+                text: "Please explain gap"
+              }, {
+                href: applicationPath + "/work-history/add/job?start=" + itemStart | date("yyyy-LL") + "&end=" + itemEnd | date("yyyy-LL") + "&referrer=" + referrer,
+                text: "Add another job"
+              }]
+            } if review == true
+          }) }}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+    {% if not hasAutomaticGaps %}
+      {% set gapsHtml %}
+        {{ govukSummaryList({
+          classes: "app-summary",
+          rows: [{
+            key: {
+              text: "Reasons for any gaps in your work history"
+            },
+            value: {
+              text: applicationValue(["work-history", "gaps"]) or "None provided" | nl2br | safe
+            },
+            actions: {
+              items: [{
+                href: applicationPath + "/work-history/explain-gaps?referrer=" + referrer,
+                text: "Change",
+                visuallyHiddenText: "reasons"
+              }]
+            }
+          }]
+        }) }}
+      {% endset %}
+      {{ appSummaryCard({
+        classes: "govuk-!-margin-bottom-6",
+        html: gapsHtml
+      }) }}
     {% endif %}
-  {% endfor %}
-  {% if not hasAutomaticGaps %}
-    {% set gapsHtml %}
+  {% else %}
+    {% set outofWorkHtml %}
       {{ govukSummaryList({
         classes: "app-summary",
         rows: [{
           key: {
-            text: "Reasons for any gaps in your work history"
+            text: "Explanation of why you’ve been out of the workplace"
           },
           value: {
-            text: applicationValue(["work-history", "gaps"]) or "None provided" | nl2br | safe
+            text: applicationValue(["work-history", "missing"]) or "Not entered" | nl2br | safe
           },
           actions: {
             items: [{
-              href: applicationPath + "/work-history/explain-gaps?referrer=" + referrer,
+              href: applicationPath + "/work-history/missing?referrer=" + referrer,
               text: "Change",
-              visuallyHiddenText: "reasons"
+              visuallyHiddenText: "explanation"
             }]
           }
         }]
@@ -142,39 +162,14 @@
     {% endset %}
     {{ appSummaryCard({
       classes: "govuk-!-margin-bottom-6",
-      html: gapsHtml
+      html: outofWorkHtml
+    }) }}
+    {{ govukButton({
+      text: "Add job",
+      classes: "govuk-button--secondary",
+      href: applicationPath + "/work-history/add/job?referrer="  + referrer
     }) }}
   {% endif %}
-{% elif hasMissing %}
-  {% set outofWorkHtml %}
-    {{ govukSummaryList({
-      classes: "app-summary",
-      rows: [{
-        key: {
-          text: "Explanation of why you’ve been out of the workplace"
-        },
-        value: {
-          text: applicationValue(["work-history", "missing"]) or "Not entered" | nl2br | safe
-        },
-        actions: {
-          items: [{
-            href: applicationPath + "/work-history/missing?referrer=" + referrer,
-            text: "Change",
-            visuallyHiddenText: "explanation"
-          }]
-        }
-      }]
-    }) }}
-  {% endset %}
-  {{ appSummaryCard({
-    classes: "govuk-!-margin-bottom-6",
-    html: outofWorkHtml
-  }) }}
-  {{ govukButton({
-    text: "Add job",
-    classes: "govuk-button--secondary",
-    href: applicationPath + "/work-history/add/job?referrer="  + referrer
-  }) }}
 {% else %}
   <p class="govuk-body">No work history entered.</p>
 {% endif %}

--- a/app/views/_layout.njk
+++ b/app/views/_layout.njk
@@ -58,7 +58,7 @@
     {% set signOutText = "Sign out" %}
   {% endif %}
 
-  {% if isSignedOut != true %}
+  {% if not isSignedOut %}
     {% if applicationValue(["status"]) == "started" %}
       {% set serviceUrl = "/application/" + applicationId %}
     {% else %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -22,8 +22,8 @@
     {% include "_includes/application-courses.njk" %}
     {% if applicationValue("courses") | length < 3 %}
       {{ govukButton({
-        classes: "govuk-button--secondary",
         text: "Add another course",
+        classes: "govuk-button--secondary",
         href: applicationPath + "/course/add"
       }) }}
     {% endif %}

--- a/app/views/application/other-qualifications/index.njk
+++ b/app/views/application/other-qualifications/index.njk
@@ -93,7 +93,7 @@
   {% if action != "edit" and not referrer %}
     {{ govukButton({
       text: "Add another qualification",
-      classes: "govuk-button--secondary",
+      classes: "govuk-button--secondary govuk-!-display-block",
       attributes: {
         formaction: applicationPath + "/other-qualifications/add"
       }

--- a/app/views/application/other-qualifications/index.njk
+++ b/app/views/application/other-qualifications/index.njk
@@ -86,6 +86,20 @@
     classes: "govuk-input--width-4"
   } | decorateApplicationAttributes(["other-qualifications", id, "year"])) }}
 
+  {# Only show ‘Add another…’ button if:
+      * not editing an existing item
+      * not referred from a review page (which also has an ‘Add another…’ button)
+  #}
+  {% if action != "edit" and not referrer %}
+    {{ govukButton({
+      text: "Add another qualification",
+      classes: "govuk-button--secondary",
+      attributes: {
+        formaction: applicationPath + "/other-qualifications/add"
+      }
+    }) }}
+  {% endif %}
+
   {{ govukButton({
     text: "Continue"
   }) }}

--- a/app/views/application/other-qualifications/review.njk
+++ b/app/views/application/other-qualifications/review.njk
@@ -17,8 +17,8 @@
   {% include "_includes/review/other-qualifications.njk" %}
   {{ govukButton({
     text: "Add another qualification",
-    classes: "govuk-button--secondary",
-    href: applicationPath + "/other-qualifications/add"
+    href: applicationPath + "/other-qualifications/add?referrer=" + referrer,
+    classes: "govuk-button--secondary"
   }) }}
 
   {{ govukCheckboxes({

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -17,9 +17,9 @@
     {% include "_includes/review/courses.njk" %}
   {% else %}
     {{ govukButton({
-      classes: "govuk-button--secondary govuk-!-font-size-16 govuk-!-padding-top-1 govuk-!-padding-bottom-1",
       text: "Add a course",
-      href: applicationPath + "/course/add"
+      href: applicationPath + "/course/add",
+      classes: "govuk-button--secondary govuk-!-font-size-16 govuk-!-padding-top-1 govuk-!-padding-bottom-1"
     }) }}
   {% endif %}
 

--- a/app/views/application/school-experience/role.njk
+++ b/app/views/application/school-experience/role.njk
@@ -120,7 +120,7 @@
   {% if action != "edit" and not referrer %}
     {{ govukButton({
       text: "Add another role",
-      classes: "govuk-button--secondary",
+      classes: "govuk-button--secondary govuk-!-display-block",
       attributes: {
         formaction: applicationPath + "/school-experience/add/role?update=" + id
       }

--- a/app/views/application/school-experience/role.njk
+++ b/app/views/application/school-experience/role.njk
@@ -113,6 +113,20 @@
     maxwords: 150
   } | decorateApplicationAttributes(["school-experience", id, "time-commitment"])) }}
 
+  {# Only show ‘Add another…’ button if:
+      * not editing an existing item
+      * not referred from a review page (which also has an ‘Add another…’ button)
+  #}
+  {% if action != "edit" and not referrer %}
+    {{ govukButton({
+      text: "Add another role",
+      classes: "govuk-button--secondary",
+      attributes: {
+        formaction: applicationPath + "/school-experience/add/role?update=" + id
+      }
+    }) }}
+  {% endif %}
+
   {{ govukButton({
     text: "Continue"
   }) }}

--- a/app/views/application/work-history/job.njk
+++ b/app/views/application/work-history/job.njk
@@ -58,7 +58,7 @@
     },
     hint: {
       text: "For example, 5 2018"
-    } if not start,
+    },
     namePrefix: id + "-start-date",
     items: [{
       label: "Month",
@@ -82,7 +82,7 @@
     },
     hint: {
       text: "For example, 5 2019"
-    } if not end,
+    },
     namePrefix: id + "-end-date",
     items: [{
       label: "Month",

--- a/app/views/application/work-history/job.njk
+++ b/app/views/application/work-history/job.njk
@@ -58,17 +58,17 @@
     },
     hint: {
       text: "For example, 5 2018"
-    },
+    } if not start,
     namePrefix: id + "-start-date",
     items: [{
       label: "Month",
       name: "month",
-      value: applicationValue(["work-history", id, "start-date"]) | date("L"),
+      value: (applicationValue(["work-history", id, "start-date"]) or start) | date('L'),
       classes: "govuk-input--width-2"
     }, {
       label: "Year",
       name: "year",
-      value: applicationValue(["work-history", id, "start-date"]) | date("yyyy"),
+      value: (applicationValue(["work-history", id, "start-date"]) or start) | date('yyyy'),
       classes: "govuk-input--width-4"
     }]
   } | decorateApplicationAttributes(["work-history", id, "start-date"])) }}
@@ -82,17 +82,17 @@
     },
     hint: {
       text: "For example, 5 2019"
-    },
+    } if not end,
     namePrefix: id + "-end-date",
     items: [{
       label: "Month",
       name: "month",
-      value: applicationValue(["work-history", id, "end-date"]) | date("L"),
+      value: (applicationValue(["work-history", id, "end-date"]) or end) | date('L'),
       classes: "govuk-input--width-2"
     }, {
       label: "Year",
       name: "year",
-      value: applicationValue(["work-history", id, "end-date"]) | date("yyyy"),
+      value: (applicationValue(["work-history", id, "end-date"]) or end) | date('yyyy'),
       classes: "govuk-input--width-4"
     }]
   } | decorateApplicationAttributes(["work-history", id, "end-date"])) }}
@@ -127,6 +127,20 @@
     name: "applications[" + applicationId + "][work-history][" + id + "][category]",
     value: "job"
   }) }}
+
+  {# Only show ‘Add another…’ button if:
+      * not editing an existing item
+      * not referred from a review page (which also has an ‘Add another…’ button)
+  #}
+  {% if action != "edit" and not referrer %}
+    {{ govukButton({
+      text: "Add another job",
+      classes: "govuk-button--secondary",
+      attributes: {
+        formaction: applicationPath + "/work-history/add/job?update=" + id
+      }
+    }) }}
+  {% endif %}
 
   {{ govukButton({
     text: "Continue"

--- a/app/views/application/work-history/job.njk
+++ b/app/views/application/work-history/job.njk
@@ -135,7 +135,7 @@
   {% if action != "edit" and not referrer %}
     {{ govukButton({
       text: "Add another job",
-      classes: "govuk-button--secondary",
+      classes: "govuk-button--secondary govuk-!-display-block",
       attributes: {
         formaction: applicationPath + "/work-history/add/job?update=" + id
       }

--- a/app/views/application/work-history/review.njk
+++ b/app/views/application/work-history/review.njk
@@ -18,8 +18,8 @@
   {% if applicationValue(["work-history", "length"]) != "none" %}
     {{ govukButton({
       text: "Add another job",
-      classes: "govuk-button--secondary",
-      href: applicationPath + "/work-history/add/job?referrer=" + referrer
+      href: applicationPath + "/work-history/add/job?referrer=" + referrer,
+      classes: "govuk-button--secondary"
     }) }}
   {% endif %}
 


### PR DESCRIPTION
- Adds ‘Add another {thing}’ when adding a new job/school experience/other qualification
  - Button doesn’t show if you decide to add another from the review page
  - Button doesn’t show if you are editing an existing item
- Update routes for work history and school experience so that we convert date components when posting to `/review` or `/add/:type`, instead of directing to an `/update` page. Required for the above change
- `saveIsoDate` now saves an end date as `now` if no date is provided, removing the need to do that in templates. Also adds a bit of error handling, skipping this function if no `id` is provided
- Normalises spacing below page heading across layouts
- Fixes reviewing an application when no data has been entered

## New button
<img width="520" alt="Screenshot 2019-09-27 at 15 09 59" src="https://user-images.githubusercontent.com/813383/65775883-ebae5600-e138-11e9-9cf0-a0f5d6987e40.png">
