### PR TITLE
Safe fallbacks for now answered branches

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -58,6 +58,25 @@ module.exports = router => {
     res.render('application/review')
   })
 
+  router.post('/application/:applicationId/review', (req, res) => {
+    // If updating jobs or roles, ensure dates are saved using ISO 8601 format
+    const id = req.query.update
+    const applicationData = utils.applicationData(req)
+    const workHistory = applicationData['work-history']
+    const schoolExperience = applicationData['school-experience']
+    const referer = req.get('referer')
+
+    if (id && referer.includes('work-history')) {
+      utils.saveIsoDate(req, workHistory, id)
+    }
+
+    if (id && referer.includes('school-experience')) {
+      utils.saveIsoDate(req, schoolExperience, id)
+    }
+
+    res.render('application/review')
+  })
+
   // Export data
   router.get('/application/:applicationId/export', (req, res) => {
     const applicationId = req.params.applicationId

--- a/app/routes/application/degree.js
+++ b/app/routes/application/degree.js
@@ -54,10 +54,10 @@ module.exports = router => {
 
   // Degree provenance answer branching
   router.post('/application/:applicationId/degree/:id/answer', (req, res) => {
-    const data = req.session.data
-    const id = req.params.id
     const applicationId = req.params.applicationId
-    const provenance = data.applications[applicationId].degree[id].provenance
+    const applicationData = utils.applicationData(req)
+    const id = req.params.id
+    const provenance = applicationData.degree[id].provenance || 'domestic'
 
     let path
     if (provenance === 'domestic' || !req.session.data.flags.international_qualifications) {

--- a/app/routes/application/school-experience.js
+++ b/app/routes/application/school-experience.js
@@ -27,9 +27,16 @@ module.exports = router => {
     const id = req.params.id
     const referrer = req.query.referrer
 
+    let formaction
+    if (referrer) {
+      formaction = `${referrer}?update=${id}`
+    } else {
+      formaction = `/application/${applicationId}/school-experience/review?update=${id}`
+    }
+
     res.render('application/school-experience/role', {
       referrer,
-      formaction: `/application/${applicationId}/school-experience/review?update=${id}`,
+      formaction,
       id
     })
   })
@@ -56,7 +63,12 @@ module.exports = router => {
   router.post('/application/:applicationId/school-experience/answer', (req, res) => {
     const applicationId = req.params.applicationId
     const applicationData = utils.applicationData(req)
-    const attained = applicationData['school-experience'].attained
+    const schoolExperience = applicationData['school-experience']
+
+    let attained
+    if (schoolExperience) {
+      attained = applicationData['school-experience'].attained
+    }
 
     if (attained === 'false') {
       res.redirect(`/application/${applicationId}/school-experience/review`)

--- a/app/routes/application/work-history.js
+++ b/app/routes/application/work-history.js
@@ -30,9 +30,16 @@ module.exports = router => {
     const id = req.params.id
     const referrer = req.query.referrer
 
+    let formaction
+    if (referrer) {
+      formaction = `${referrer}?update=${id}`
+    } else {
+      formaction = `/application/${applicationId}/work-history/review?update=${id}`
+    }
+
     res.render(`application/work-history/${type}`, {
       referrer,
-      formaction: `/application/${applicationId}/work-history/review?update=${id}`,
+      formaction,
       id,
       start: `${req.query.start}`,
       end: `${req.query.end}`
@@ -62,7 +69,12 @@ module.exports = router => {
   router.post('/application/:applicationId/work-history/answer', (req, res) => {
     const applicationId = req.params.applicationId
     const applicationData = utils.applicationData(req)
-    const length = applicationData['work-history'].length
+    const workHistory = applicationData['work-history']
+
+    let length
+    if (workHistory) {
+      length = applicationData['work-history'].length
+    }
 
     if (length === 'none') {
       res.redirect(`/application/${applicationId}/work-history/missing`)

--- a/app/views/_includes/item/degree.njk
+++ b/app/views/_includes/item/degree.njk
@@ -1,8 +1,12 @@
 {% set applicationPath = "/application/" + applicationId %}
 
 {% set qualificationText -%}
-  {{- item.type + " " + item.subject if item.type }}
-  {{ item.org + ", " + item.country if item.org }}
+  {%- if item.type -%}
+    {{- item.type + " " + item.subject if item.type }}
+    {{ item.org + ", " + item.country if item.org }}
+  {%- else -%}
+    Not entered
+  {%- endif -%}
 {%- endset %}
 
 {{ govukSummaryList({
@@ -11,7 +15,7 @@
       text: "Qualification"
     },
     value: {
-      text: (qualificationText | nl2br | safe) or "Not entered"
+      text: qualificationText | nl2br | safe
     },
     actions: {
       items: [{

--- a/app/views/_includes/item/gap.njk
+++ b/app/views/_includes/item/gap.njk
@@ -22,7 +22,7 @@
       text: "Description"
     },
     value: {
-      text: item.description or "Not entered"
+      text: (item.description or "Not entered") | nl2br | safe
     },
     actions: {
       items: [{

--- a/app/views/_includes/item/gcse.njk
+++ b/app/views/_includes/item/gcse.njk
@@ -3,10 +3,14 @@
 {% set nonUK = item.type == "Non-UK qualification" %}
 
 {% set qualificationText -%}
-  {{- (item["type-uk"] if item["type-uk"]) or (item["type-non-uk"] if item["type-non-uk"]) or item.type }}
-  {%- if nonUK %}
-    {{ item["award-org"] + ", " + item.country if item["award-org"] }}
-  {% endif %}
+  {%- if item["type-uk"] or item["type-non-uk"] or item.type %}
+    {{- (item["type-uk"] if item["type-uk"]) or (item["type-non-uk"] if item["type-non-uk"]) or item.type }}
+    {%- if nonUK -%}
+      {{ item["award-org"] + ", " + item.country if item["award-org"] }}
+    {%- endif %}
+  {%- else -%}
+    Not entered
+  {%- endif -%}
 {%- endset %}
 
 {{ govukSummaryList({
@@ -29,7 +33,7 @@
       text: "Qualification"
     },
     value: {
-      text: (qualificationText | nl2br | safe) or "Not entered"
+      text: qualificationText | nl2br | safe
     },
     actions: {
       items: [{

--- a/app/views/_includes/item/job.njk
+++ b/app/views/_includes/item/job.njk
@@ -1,9 +1,13 @@
 {% set applicationPath = "/application/" + applicationId %}
 
 {% set jobHtml -%}
-  {{ item.role }}
-  {%- if item.org %}
-    <br><span class="govuk-visually-hidden">at</span>{{ item.org }}
+  {% if item.role %}
+    {{ item.role }}
+    {%- if item.org %}
+      <br><span class="govuk-visually-hidden">at</span>{{ item.org }}
+    {% endif %}
+  {% else %}
+    Not entered
   {% endif %}
 {%- endset %}
 
@@ -47,7 +51,7 @@
       text: "Description"
     },
     value: {
-      text: (item.description | nl2br | safe) or "Not entered"
+      text: (item.description or "Not entered") | nl2br | safe
     },
     actions: {
       items: [{

--- a/app/views/_includes/item/role.njk
+++ b/app/views/_includes/item/role.njk
@@ -1,10 +1,14 @@
 {% set applicationPath = "/application/" + applicationId %}
 
 {% set datesHtml -%}
-  {{- item["start-date"] | date("MMMM yyyy") }} - {{ item["end-date"] | date("MMMM yyyy") if item["end-date"] != "now" else "Present" }}
-  {%- if item["time-commitment"] -%}
-    <br>{{ item["time-commitment"] | nl2br | safe }}
-  {%- endif %}
+  {%- if item["start-date"] or item["time-commitment"] -%}
+    {{- item["start-date"] | date("MMMM yyyy") }} - {{ item["end-date"] | date("MMMM yyyy") if item["end-date"] != "now" else "Present" }}
+    {%- if item["time-commitment"] -%}
+      <br>{{ item["time-commitment"] | nl2br | safe }}
+    {%- endif -%}
+  {%- else -%}
+    Not entered
+  {%- endif -%}
 {% endset %}
 
 {% set changeHref = applicationPath + "/school-experience/role/" + item.id + "?referrer=" + referrer %}

--- a/app/views/_includes/review/degrees.njk
+++ b/app/views/_includes/review/degrees.njk
@@ -1,5 +1,5 @@
 {% set applicationPath = "/application/" + applicationId %}
-{% set degrees = applicationValue(["degrees"]) %}
+{% set degrees = applicationValue(["degree"]) %}
 
 {% if degrees %}
   {% set degrees = degrees | toArray | selectattr("id") %}

--- a/app/views/_includes/review/work-history.njk
+++ b/app/views/_includes/review/work-history.njk
@@ -148,7 +148,7 @@
             text: "Explanation of why you’ve been out of the workplace"
           },
           value: {
-            text: applicationValue(["work-history", "missing"]) or "Not entered" | nl2br | safe
+            text: (applicationValue(["work-history", "missing"]) or "Not entered") | nl2br | safe
           },
           actions: {
             items: [{


### PR DESCRIPTION
- Ensures any radio questions that have follow on branching logic, a non-answer doesn’t break the prototype or send user in a loop
- Ensure job and role dates are still updated as ISO 8601 if editing from application review page
- Fixes job/role form action to return to referring page (if provided)
- Fixes a cases of ‘Not entered’ not appearing if no data entered for a question