### PR TITLE
Prefill qualifications based on earlier values

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -87,7 +87,7 @@ module.exports = {
           org: 'Juliet High School',
           grade: '173',
           year: '2004',
-          international: 'yes',
+          provenance: 'international',
           country: 'India'
         },
         kv0y7: {
@@ -97,7 +97,7 @@ module.exports = {
           org: 'Juliet High School',
           grade: '647',
           year: '2008',
-          international: 'yes',
+          provenance: 'international',
           country: 'India'
         }
       },

--- a/app/utils/filters-with-app-context.js
+++ b/app/utils/filters-with-app-context.js
@@ -24,7 +24,7 @@ module.exports = (nunjucksAppEnv, app) => {
       // Get the most recently added qualification
       var qualifications = getApplicationValue(sections.slice(0,1))
 
-      if (!qualifications || qualifications.length == 0) {
+      if (!qualifications || Object.values(qualifications).length == 0) {
         return null
       }
 

--- a/app/utils/filters-with-app-context.js
+++ b/app/utils/filters-with-app-context.js
@@ -38,7 +38,15 @@ module.exports = (nunjucksAppEnv, app) => {
     // Generate the attributes based on the application ID and the section they’re in
     nunjucksAppEnv.addFilter('decorateApplicationAttributes', (obj, sections) => {
       sections = sections || []
-      const storedValue = getApplicationValue(sections)
+      var storedValue = getApplicationValue(sections)
+
+      // Prefill qualification values based on previous answers
+      if (!storedValue
+            && !sections.includes('completed')
+            && sections.includes('other-qualifications')) {
+
+        storedValue = prefillPreviousQualificationValues(sections)
+      }
 
       if (obj.items !== undefined) {
         obj.items = obj.items.map(item => {
@@ -68,14 +76,6 @@ module.exports = (nunjucksAppEnv, app) => {
         obj.value = storedValue
       }
 
-      // Prefill qualification values based on previous answers
-      if (!obj.value
-            && !sections.includes('completed')
-            && sections.includes('other-qualifications')) {
-
-        obj.value = prefillPreviousQualificationValues(sections)
-      }
-
       obj.id = sections.join('-')
       obj.name = `applications[${applicationId()}]${sections.map(s => `[${s}]`).join('')}`
       return obj
@@ -94,6 +94,14 @@ module.exports = (nunjucksAppEnv, app) => {
       }
 
       return getApplicationValue(sections)
+    })
+
+    nunjucksAppEnv.addGlobal('valueOrPreviousQualificationValue', (sections) => {
+      if (sections && !Array.isArray(sections)) {
+        sections = [sections]
+      }
+
+      return getApplicationValue(sections) || prefillPreviousQualificationValues(sections)
     })
 
     nunjucksAppEnv.addFilter('getCourseFromProviderCode', providerCode => {

--- a/app/views/application/other-qualifications/index.njk
+++ b/app/views/application/other-qualifications/index.njk
@@ -1,5 +1,6 @@
 {% extends "_form.njk" %}
 
+{% set applicationPath = "/application/" + applicationId %}
 {% set title = "Other relevant qualifications" %}
 
 {% block pageNavigation %}

--- a/app/views/application/other-qualifications/index.njk
+++ b/app/views/application/other-qualifications/index.njk
@@ -111,7 +111,7 @@
   <script src="/public/javascripts/autocomplete.min.js"></script>
   <script>
     accessibleAutocomplete.enhanceSelectElement({
-      defaultValue: '{{ applicationValue(["other-qualifications", id, "country"]) }}',
+      defaultValue: '{{ valueOrPreviousQualificationValue(["other-qualifications", id, "country"]) }}',
       selectElement: document.querySelector('#other-qualifications-{{ id }}-country')
     })
   </script>


### PR DESCRIPTION
Allow applications to reuse school, year and qualification type when they add another qualification.

Prefills:
- Type of qualification
- Name of school
- In UK/out of UK
- Country if provided
- Year

Does't prefill:
- Subject
- Grade

## Example of a prefilled qualification

![Screen Shot 2019-10-14 at 15 55 29](https://user-images.githubusercontent.com/319055/66761007-16b7da00-ee9b-11e9-9025-a5578d05c144.png)
