### PR TITLE
Stub "Apply on UCAS" page in course flow

### DIFF
--- a/app/views/application/choices/pick.njk
+++ b/app/views/application/choices/pick.njk
@@ -1,15 +1,15 @@
 {% extends "_form.njk" %}
 
-{% set providerOnDfEApply = true %}
-{% set title = "Which course are you applying to?" if providerOnDfEApply else "You need to apply on UCAS" %}
-{% set formaction = paths.next %}
-{% set applicationPath = "/application/" + applicationId %}
 {% set editing = applicationValue(["choices", choiceId]) %}
 {% if editing %}
   {% set providerCode = applicationValue(["choices", choiceId, "providerCode"]) %}
 {% else %}
   {% set providerCode = applicationValue(["temporaryChoices", choiceId, "provider"]) | providerCode %}
 {% endif %}
+{% set providerOnDfEApply = false if providerCode == 'B20' else true %}
+{% set title = "Which course are you applying to?" if providerOnDfEApply else "You need to apply on UCAS" %}
+{% set formaction = paths.next %}
+{% set applicationPath = "/application/" + applicationId %}
 
 {% block pageNavigation %}
   {{ govukBackLink({

--- a/app/views/application/choices/pick.njk
+++ b/app/views/application/choices/pick.njk
@@ -1,7 +1,7 @@
 {% extends "_form.njk" %}
 
 {% set providerOnDfEApply = true %}
-{% set title = "Which course are you applying to?" if providerOnDfEApply else "You need to apply for this course on UCAS" %}
+{% set title = "Which course are you applying to?" if providerOnDfEApply else "You need to apply on UCAS" %}
 {% set formaction = paths.next %}
 {% set applicationPath = "/application/" + applicationId %}
 {% set editing = applicationValue(["choices", choiceId]) %}
@@ -29,18 +29,24 @@
     }) }}
   {% else %}
     <p>For now, the Department for Education’s Apply for teacher training service is limited to just a few training providers.</p>
-    <p>The course you’ve chosen is not signed up to the new service. This means you must apply for it using UCAS.</p>
+    <p>The training provider you’ve chosen is not signed up to the new service. This means you must apply for it using UCAS.</p>
     <p>You’ll need to register with UCAS before you can apply.</p>
 
     {# <p>Visit Get into Teaching for <a href="/apply/get-into-teaching">guidance on applying for teacher training through UCAS</a>. #}
+
+    <p class="govuk-body">You can also:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><a href="/apply/get-into-teaching">Learn more about changes to teacher training applications</a></li>
+      <li><a href="/apply/providers">Check the list of training providers</a> signed up to Apply for teacher training</li>
+    </ul>
+
+    <hr class="govuk-section-break govuk-section-break--l">
 
     <p>
       <a href="https://2020.teachertraining.apply.ucas.com/apply/student/login.do" class="govuk-button govuk-!-margin-bottom-0">Apply on UCAS</a>
     </p>
 
-    <p class="govuk-body govuk-!-font-weight-bold">You can also:</p>
-    <p class="govuk-body"><a href="/apply/get-into-teaching">Learn more about changes to teacher training applications</a></p>
-    <p class="govuk-body"><a href="/apply/providers">Check the list of training providers</a> signed up to Apply for teacher training</p>
+    <p>or</p>
 
     <p class="govuk-body">
       <a href="{{ applicationPath }}" class="govuk-button govuk-button--secondary">Return to your application</a>

--- a/app/views/application/choices/pick.njk
+++ b/app/views/application/choices/pick.njk
@@ -1,7 +1,9 @@
 {% extends "_form.njk" %}
 
-{% set title = "Which course are you applying to?" %}
+{% set providerOnDfEApply = true %}
+{% set title = "Which course are you applying to?" if providerOnDfEApply else "You need to apply for this course on UCAS" %}
 {% set formaction = paths.next %}
+{% set applicationPath = "/application/" + applicationId %}
 {% set editing = applicationValue(["choices", choiceId]) %}
 {% if editing %}
   {% set providerCode = applicationValue(["choices", choiceId, "providerCode"]) %}
@@ -16,44 +18,66 @@
 {% endblock %}
 
 {% block primary %}
-  <div class="govuk-form-group">
-    <label for="courses-{{ choiceId }}-course" class="govuk-label">Enter course name and code</label>
-    <div id="course-autocomplete-container"></div>
-  </div>
+  {% if providerOnDfEApply %}
+    <div class="govuk-form-group">
+      <label for="courses-{{ choiceId }}-course" class="govuk-label">Enter course name and code</label>
+      <div id="course-autocomplete-container"></div>
+    </div>
 
-  {{ govukButton({
-    text: "Continue"
-  }) }}
+    {{ govukButton({
+      text: "Continue"
+    }) }}
+  {% else %}
+    <p>For now, the Department for Education’s Apply for teacher training service is limited to just a few training providers.</p>
+    <p>The course you’ve chosen is not signed up to the new service. This means you must apply for it using UCAS.</p>
+    <p>You’ll need to register with UCAS before you can apply.</p>
+
+    {# <p>Visit Get into Teaching for <a href="/apply/get-into-teaching">guidance on applying for teacher training through UCAS</a>. #}
+
+    <p>
+      <a href="https://2020.teachertraining.apply.ucas.com/apply/student/login.do" class="govuk-button govuk-!-margin-bottom-0">Apply on UCAS</a>
+    </p>
+
+    <p class="govuk-body govuk-!-font-weight-bold">You can also:</p>
+    <p class="govuk-body"><a href="/apply/get-into-teaching">Learn more about changes to teacher training applications</a></p>
+    <p class="govuk-body"><a href="/apply/providers">Check the list of training providers</a> signed up to Apply for teacher training</p>
+
+    <p class="govuk-body">
+      <a href="{{ applicationPath }}" class="govuk-button govuk-button--secondary">Return to your application</a>
+    </p>
+  {% endif %}
 {% endblock %}
 
 {% block pageScripts %}
-  <script src="/public/javascripts/autocomplete.min.js"></script>
-  <script>
-    {% set provider = providers[providerCode] %}
-    {% if editing %}
-      {% set defaultValue = provider.courses[applicationValue(["choices", choiceId, "courseCode"])].name_and_code %}
+  {% if providerOnDfEApply %}
+    <script src="/public/javascripts/autocomplete.min.js"></script>
+    <script>
+      {% set provider = providers[providerCode] %}
+      {% if editing %}
+        {% set defaultValue = provider.courses[applicationValue(["choices", choiceId, "courseCode"])].name_and_code %}
 
-      accessibleAutocomplete({
-        defaultValue: "",
-        name: "applications[{{ applicationId }}][temporaryChoices][{{ choiceId }}][course]",
-        element: document.querySelector('#course-autocomplete-container'),
-        id: 'courses-{{ choiceId }}-course',
-        showAllValues: true,
-        source: [
-          {% for id, item in provider.courses %}"{{ item.name_and_code }}",{% endfor %}
-        ]
-      })
-    {% else %}
-      accessibleAutocomplete({
-        defaultValue: '{{ applicationValue(["temporaryChoices", choiceId, "course"]) }}',
-        name: "applications[{{ applicationId }}][temporaryChoices][{{ choiceId }}][course]",
-        element: document.querySelector('#course-autocomplete-container'),
-        id: 'courses-{{ choiceId }}-course',
-        showAllValues: true,
-        source: [
-          {% for id, item in provider.courses %}"{{ item.name_and_code }}",{% endfor %}
-        ]
-      })
-    {% endif %}
-  </script>
+        accessibleAutocomplete({
+          defaultValue: "",
+          name: "applications[{{ applicationId }}][temporaryChoices][{{ choiceId }}][course]",
+          element: document.querySelector('#course-autocomplete-container'),
+          id: 'courses-{{ choiceId }}-course',
+          showAllValues: true,
+          source: [
+            {% for id, item in provider.courses %}"{{ item.name_and_code }}",{% endfor %}
+          ]
+        })
+      {% else %}
+        accessibleAutocomplete({
+          defaultValue: '{{ applicationValue(["temporaryChoices", choiceId, "course"]) }}',
+          name: "applications[{{ applicationId }}][temporaryChoices][{{ choiceId }}][course]",
+          element: document.querySelector('#course-autocomplete-container'),
+          id: 'courses-{{ choiceId }}-course',
+          showAllValues: true,
+          source: [
+            {% for id, item in provider.courses %}"{{ item.name_and_code }}",{% endfor %}
+          ]
+        })
+      {% endif %}
+    </script>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
- keep full list of providers so candidates can always find who they’re looking for
- if a provider who isn’t in pilot is picked, give a route to UCAS, maybe some guidance, maybe a link to the dual running page on GiT

![Screen Shot 2019-10-15 at 15 09 51](https://user-images.githubusercontent.com/319055/66839148-df5e3180-ef5d-11e9-84cd-78ee3dea7df5.png)
