### PR TITLE
Move pilot eligibility questions to cover all routes in

### DIFF
--- a/app/assets/sass/components/_related.scss
+++ b/app/assets/sass/components/_related.scss
@@ -1,8 +1,21 @@
 .app-related {
-  border-top: govuk-spacing(1) solid govuk-colour("blue");
+  border-top: 2px solid govuk-colour("blue");
   padding-top: govuk-spacing(3);
 }
 
 .app-related + .app-related {
   border-top-color: transparent;
+}
+
+.app-related__body {
+  @include govuk-font(16);
+}
+
+.app-related__list {
+  @extend %govuk-list;
+}
+
+.app-related__list-item {
+  @include govuk-font(16);
+  margin-top: govuk-spacing(3);
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -16,6 +16,7 @@ router.all([
   next()
 })
 
+require('./routes/account')(router)
 require('./routes/delete')(router) // Must appear before other routes
 require('./routes/apply')(router)
 require('./routes/application')(router)

--- a/app/routes/account.js
+++ b/app/routes/account.js
@@ -1,0 +1,14 @@
+/**
+ * Account routes
+ */
+module.exports = router => {
+  router.get('/account/eligibility/answer', (req, res) => {
+    const eligibileNationality = req.session.data['eligibile-nationality']
+    const eligibileEquivalencies = req.session.data['eligibile-equivalencies']
+    if (eligibileNationality === 'no' || eligibileEquivalencies === 'no') {
+      res.redirect('/account/ineligible') // Show UCAS Apply information
+    } else {
+      res.redirect('/account/create-account') // Create an account
+    }
+  })
+}

--- a/app/routes/apply.js
+++ b/app/routes/apply.js
@@ -19,45 +19,18 @@ module.exports = router => {
     const courseCode = req.query.course
 
     // Count this so we can act on the data
-    // eg We show them a course that's only on UCAS the second time around
-    req.session.data['visits_from_find'] = req.session.data['visits_from_find'] + 1
+    // eg We show them a course that’s only on UCAS the second time around
+    req.session.data.visits_from_find = req.session.data.visits_from_find + 1
 
     res.redirect(`/apply/${providerCode}/${courseCode}?dualrunning=true`)
   })
 
   router.get('/apply/:providerCode/:courseCode/answer', (req, res) => {
-    const providerCode = req.params.providerCode
-    const courseCode = req.params.courseCode
-
     const route = req.session.data['apply-route']
     if (route === 'ucas') {
-      res.redirect('https://2020.teachertraining.apply.ucas.com/apply/student/login.do')
+      res.redirect('https://2020.teachertraining.apply.ucas.com/apply/student/login.do') // Go to UCAS
     } else {
-      res.redirect(`/apply/${providerCode}/${courseCode}/eligibility`)
-    }
-  })
-
-  router.get('/apply/:providerCode/:courseCode/eligibility', (req, res) => {
-    const providerCode = req.params.providerCode
-    const courseCode = req.params.courseCode
-
-    res.render('apply/eligibility', {
-      formaction: `/apply/${providerCode}/${courseCode}/eligibility/answer`,
-      providerCode,
-      courseCode
-    })
-  })
-
-  router.get('/apply/:providerCode/:courseCode/eligibility/answer', (req, res) => {
-    const providerCode = req.params.providerCode
-    const courseCode = req.params.courseCode
-
-    const eligibileNationality = req.session.data['eligibile-nationality']
-    const eligibileEquivalencies = req.session.data['eligibile-equivalencies']
-    if (eligibileNationality === 'no' || eligibileEquivalencies === 'no') {
-      res.redirect(`/apply/${providerCode}/${courseCode}/?ineligible=true`) // Show UCAS apply information
-    } else {
-      res.redirect('/') // Apply for teacher training service
+      res.redirect('/') // Go to Apply
     }
   })
 

--- a/app/views/_components/related/template.njk
+++ b/app/views/_components/related/template.njk
@@ -1,14 +1,14 @@
 <aside class="app-related{%- if params.classes %} {{ params.classes }}{% endif %}" role="complementary">
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-2" id="{{ params.name }}-title">{{ params.title }}</h2>
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="{{ params.name }}-title">{{ params.title }}</h2>
   {% if params.content.html or params.content.text %}
-  <div class="govuk-body">
+  <div class="govuk-body-s">
     {{ params.content.html | safe if params.content.html else params.content.text }}
   </div>
   {% endif %}
   <nav role="navigation" aria-labelledby="{{ params.name }}-title">
-    <ul class="govuk-list govuk-!-font-size-16">
+    <ul class="app-related__list">
     {% for item in params.items %}
-      <li>
+      <li class="app-related__list-item">
         <a class="govuk-link" href="{{ item.href }}">{{ item.text }}</a>
       </li>
     {% endfor %}

--- a/app/views/_guidance.njk
+++ b/app/views/_guidance.njk
@@ -1,0 +1,22 @@
+{% extends "_layout.njk" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+    {% if title %}
+      <h1 class="govuk-heading-xl">
+        {% if parent %}<span class="govuk-caption-xl">{{ parent }}</span>{% endif %}
+        {{ title | safe }}
+      </h1>
+    {% endif %}
+    {% block primary %}
+    {% endblock %}
+    </div>
+    {% if hasSecondary %}
+    <div class="govuk-grid-column-one-third">
+      {% block secondary %}
+      {% endblock %}
+    </div>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/app/views/account/create-account.njk
+++ b/app/views/account/create-account.njk
@@ -1,6 +1,6 @@
 {% extends "_form.njk" %}
 
-{% set title = "Before you begin" %}
+{% set title = "Please give us your email address" %}
 {% set formaction = "/account/check-email/create-account" %}
 {% set isSignedOut = true %}
 
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body-l">Please give us your email address so that you can save and return to your application.</p>
+  <p class="govuk-body-l">You'll then be able to save and return to your application.</p>
 
   {{ govukInput({
     label: {

--- a/app/views/account/eligibility.njk
+++ b/app/views/account/eligibility.njk
@@ -1,6 +1,6 @@
 {% extends "_form.njk" %}
 
-{% set title = "Check you can use this service" %}
+{% set title = "First, check you can use GOV.UK Apply" %}
 {% set formaction = "/account/eligibility/answer" %}
 {% set isSignedOut = true %}
 
@@ -17,7 +17,7 @@
     name: "eligibile-nationality",
     fieldset: {
       legend: {
-        text: "Are you a citizen of the UK/EU/EEA?",
+        text: "Are you a citizen of the UK, EU or EEA?",
         classes: "govuk-fieldset__legend--m"
       }
     },

--- a/app/views/account/eligibility.njk
+++ b/app/views/account/eligibility.njk
@@ -1,6 +1,7 @@
 {% extends "_form.njk" %}
 
-{% set title = "Check you can use GOV.UK Apply" %}
+{% set title = "Check you can use this service" %}
+{% set formaction = "/account/eligibility/answer" %}
 {% set isSignedOut = true %}
 
 {% block pageNavigation %}

--- a/app/views/account/ineligible.njk
+++ b/app/views/account/ineligible.njk
@@ -1,0 +1,30 @@
+{% extends "_guidance.njk" %}
+
+{% set title = "We’re sorry, but you’re not eligible to use this service" %}
+{% set isSignedOut = true %}
+{% set hasSecondary = true %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    "href": "/account/eligibility"
+  }) }}
+{% endblock %}
+
+{% block primary %}
+  <p class="govuk-body">The service is still in development, so we have to limit candidate numbers. This means you must apply for it using UCAS.</p>
+  <p class="govuk-body">You’ll need to register with UCAS before you can apply.</p>
+  <p><a href="https://2020.teachertraining.apply.ucas.com/apply/student/login.do" class="govuk-button govuk-!-margin-bottom-0">Apply on UCAS</a></p>
+{% endblock %}
+
+{% block secondary %}
+  {{ appRelated({
+    title: "Related content",
+    items: [{
+      text: "Upcoming changes to teacher training applications",
+      href: "/apply/get-into-teaching"
+    }, {
+      text: "Guidance on applying for teacher training through UCAS",
+      href: "https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training/apply-to-teacher-training"
+    }]
+  }) }}
+{% endblock %}

--- a/app/views/account/ineligible.njk
+++ b/app/views/account/ineligible.njk
@@ -1,6 +1,6 @@
 {% extends "_guidance.njk" %}
 
-{% set title = "We’re sorry, but you’re not eligible to use this service" %}
+{% set title = "We’re sorry, but you’re not eligible to use GOV.UK Apply" %}
 {% set isSignedOut = true %}
 {% set hasSecondary = true %}
 
@@ -11,7 +11,8 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">The service is still in development, so we have to limit candidate numbers. This means you must apply for it using UCAS.</p>
+  <p class="govuk-body">This service is still in development, so we have to limit candidate numbers.</p>
+  <p class="govuk-body govuk-!-font-weight-bold">You can apply for all teacher training courses and providers using UCAS.</p>
   <p class="govuk-body">You’ll need to register with UCAS before you can apply.</p>
   <p><a href="https://2020.teachertraining.apply.ucas.com/apply/student/login.do" class="govuk-button govuk-!-margin-bottom-0">Apply on UCAS</a></p>
 {% endblock %}

--- a/app/views/application/choices/pick.njk
+++ b/app/views/application/choices/pick.njk
@@ -39,15 +39,9 @@
       <li><a href="/apply/get-into-teaching">Learn more about changes to teacher training applications</a></li>
       <li><a href="/apply/providers">Check the list of training providers</a> signed up to Apply for teacher training</li>
     </ul>
-
     <hr class="govuk-section-break govuk-section-break--l">
-
-    <p>
-      <a href="https://2020.teachertraining.apply.ucas.com/apply/student/login.do" class="govuk-button govuk-!-margin-bottom-0">Apply on UCAS</a>
-    </p>
-
-    <p>or</p>
-
+    <p class="govuk-body"><a href="https://2020.teachertraining.apply.ucas.com/apply/student/login.do" class="govuk-button govuk-!-margin-bottom-0">Apply on UCAS</a></p>
+    <p class="govuk-body">or</p>
     <p class="govuk-body">
       <a href="{{ applicationPath }}" class="govuk-button govuk-button--secondary">Return to your application</a>
     </p>

--- a/app/views/apply/index.njk
+++ b/app/views/apply/index.njk
@@ -4,8 +4,6 @@
 {% if course %}
   {% if dualRunning %}
     {% set title = "Choose how to apply" %}
-  {% elif ineligible %}
-    {% set title = "Please continue your application using UCAS" %}
   {% else %}
     {% set title = "Apply for this course" %}
   {% endif %}
@@ -19,17 +17,6 @@
   {{ govukBackLink({
     "href": "javascript: window.history.go(-1)"
   }) }}
-{% endblock %}
-
-{% block pageBanner %}
-  {% if ineligible %}
-    {{ appBanner({
-      classes: "govuk-!-margin-bottom-0",
-      type: "information",
-      html: "<h2 class=\"govuk-heading-s govuk-!-margin-bottom-0\">We’re sorry, but you’re not eligible to use GOV.UK Apply.</h2><p class=\"govuk-body\">The service is still in development, so we have to limit candidate numbers.</p>",
-      iconFallbackText: "Information"
-    }) }}
-  {% endif %}
 {% endblock %}
 
 {% block primary %}
@@ -96,14 +83,6 @@
 
     {{ govukButton({
       text: "Continue"
-    }) }}
-  {% elif course and ineligible %}
-    {{ courseCodeHtml | safe }}
-
-    {{ govukButton({
-      text: "Apply through UCAS",
-      href: "https://2020.teachertraining.apply.ucas.com/apply/student/login.do",
-      isStartButton: true
     }) }}
   {% elif course and not dualRunning %}
     <p class="govuk-body">You must apply for this course on UCAS. You’ll need to register with UCAS before you can apply.</p>

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -46,7 +46,7 @@
 {% else %}
   {{ govukButton({
     text: "Start now",
-    href: "/account/create-account",
+    href: "/account/eligibility",
     isStartButton: true,
     classes: "govuk-!-margin-top-4 govuk-!-margin-bottom-3"
   }) }}


### PR DESCRIPTION
## What’s changed

- Moves pilot eligibility questions so that they appear after the ‘Start now’ action from the service landing page. This is so that we can shift candidates regardless of their route in.
- Interstitial from Find is now a simple choice between the respective Apply and UCAS URLs (if course/provider is opted in).

### Check you are eligible
`/account/eligibility`

![Screenshot 2019-10-17 at 16 07 45](https://user-images.githubusercontent.com/813383/67022270-dfdeff80-f0f8-11e9-8b3f-a42c23e840d8.png)

### Not eligible
`/account/ineligible`

![Screenshot 2019-10-17 at 16 07 37](https://user-images.githubusercontent.com/813383/67022279-e4a3b380-f0f8-11e9-9954-162d49e049f3.png)

## Things to check
- The content on the ineligible page needs review. Is providing links to related content in a sidebar the right approach. Are those the right links?
- If you are eligible, is ‘Before you start’ still the right title for the following page?
- Should the page we show when choosing a non-opted on course align more closely with this design (i.e. with the sidebar links)?

## Improvements
- When we add carrying over course details from Find, we should also ensure that functionality is used on this flow so that we show the provider and course codes to use when applying via UCAS application.