### PR TITLE
Add training with a disability section

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -88,6 +88,7 @@ module.exports = router => {
   require('./application/contact-details')(router)
   require('./application/work-history')(router)
   require('./application/school-experience')(router)
+  require('./application/disability')(router)
   require('./application/vocation')(router)
   require('./application/degree')(router)
   require('./application/gcse')(router)

--- a/app/routes/application/disability.js
+++ b/app/routes/application/disability.js
@@ -1,0 +1,25 @@
+const utils = require('./../../utils')
+
+/**
+ * Application: Disability routes
+ */
+module.exports = router => {
+  // First page
+  router.get('/application/:applicationId/disability', (req, res) => {
+    const referrer = req.query.referrer
+
+    res.render('application/disability/index', {
+      referrer,
+      formaction: `/application/${req.params.applicationId}/disability/review`
+    })
+  })
+
+  // Render other disability pages
+  router.get('/application/:applicationId/disability/:view', (req, res) => {
+    const referrer = req.query.referrer
+
+    res.render(`application/disability/${req.params.view}`, {
+      referrer
+    })
+  })
+}

--- a/app/views/_includes/review/disability.njk
+++ b/app/views/_includes/review/disability.njk
@@ -1,0 +1,43 @@
+{% set applicationPath = "/application/" + applicationId %}
+{% set disabilityDetailsHtml %}
+  {{ govukSummaryList({
+    rows: [{
+      key: {
+        text: "Disclose a disability?"
+      },
+      value: {
+        text: applicationValue(["disability", "disclose"])
+      },
+      actions: {
+        items: [{
+          href: applicationPath + "/disability?referrer=" + referrer,
+          text: "Change",
+          visuallyHiddenText: "if you want to disclose a disability"
+        }]
+      } if review
+    }, {
+      key: {
+        text: "About your disability"
+      },
+      value: {
+        html: applicationValue(["disability", "about-disability"])
+      },
+      actions: {
+        items: [{
+          href: applicationPath + "/disability?referrer=" + referrer,
+          text: "Change",
+          visuallyHiddenText: "details about your disability"
+        }]
+      } if review
+    } if applicationValue(["disability", "disclose"]) == 'Yes']
+  }) }}
+{% endset %}
+
+{% if applicationValue("disability") %}
+  {{ appSummaryCard({
+    classes: "govuk-!-margin-bottom-6",
+    html: disabilityDetailsHtml
+  }) }}
+{% else %}
+  <p class="govuk-body">No choice made about disclosing a disability.</p>
+{% endif %}

--- a/app/views/application/disability/index.njk
+++ b/app/views/application/disability/index.njk
@@ -1,0 +1,59 @@
+{% extends "_form.njk" %}
+
+{% set title = "Training with a disability" %}
+
+{% block pageNavigation %}
+  {% if referrer %}
+    {{ govukBackLink({
+      href: referrer
+    }) }}
+  {% else %}
+    {{ govukBackLink({
+      href: "/application/" + applicationId,
+      text: "Back to application"
+    }) }}
+  {% endif %}
+{% endblock %}
+
+{% block primary %}
+  <p>It’s a personal choice if you want to inform your training provider of your disability.</p>
+
+  <p>The advantage of disclosure is that it enables support and reasonable adjustments to be put in place. In addition, specialist equipment, extra funding and support, can help you achieve your ambition of becoming a teacher.</p>
+
+  <p><a href="https://www.gov.uk/guidance/equality-act-2010-guidance">The Equality Act 2010</a> and Special Educational Needs and Disability Act 2001, require teacher training providers to ensure they are not discriminating against applicants with disabilities or special educational needs (SEN).</p>
+
+  {# <p>Schools have a duty to make reasonable adjustments to avoid putting disabled at a substantial disadvantage compared to non-disabled pupils</p> #}
+
+  {% set disabilityConditional %}
+    {{ govukCharacterCount({
+      label: {
+        text: "Tell us about your disability",
+        classes: "govuk-label--s"
+      },
+      maxwords: 400,
+      rows: 24
+    } | decorateApplicationAttributes(["disability", "about-disability"])) }}
+  {% endset %}
+
+  {{ govukRadios({
+    fieldset: {
+      classes: "govuk-!-margin-top-6",
+      legend: {
+        text: "Do you want to disclose a disability?",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    items: [{
+      text: "Yes",
+      conditional: {
+        html: disabilityConditional
+      }
+    }, {
+      text: "No"
+    }]
+  } | decorateApplicationAttributes(["disability", "disclose"])) }}
+
+  {{ govukButton({
+    text: "Continue"
+  }) }}
+{% endblock %}

--- a/app/views/application/disability/review.njk
+++ b/app/views/application/disability/review.njk
@@ -1,0 +1,21 @@
+{% extends "_content-wide.njk" %}
+
+{% set applicationPath = "/application/" + applicationId %}
+{% set referrer = applicationPath + "/disabilities/review" %}
+{% set title = "Training with a disability" %}
+{% set review = true %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/application/" + applicationId,
+    text: "Back to application"
+  }) }}
+{% endblock %}
+
+{% block primary %}
+  {% include "_includes/review/disability.njk" %}
+  {{ govukButton({
+    text: "Continue",
+    href: applicationPath
+  }) }}
+{% endblock %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -51,7 +51,12 @@
       href: applicationPath + "/school-experience" + ("/review" if applicationValue("school-experience")),
       id: "school-experience",
       completed: applicationValue(["completed", "school-experience"])
-    }]
+    }, {
+     text: "Training with a disability",
+     href: applicationPath + "/disability" + ("/review" if applicationValue("disability")),
+     id: "disability",
+     completed: applicationValue("disability")
+   }]
   }) }}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">Qualifications</h2>

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -36,6 +36,9 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27">Volunteering with children and young people</h2>
   {% include "_includes/review/school-experience.njk" %}
 
+  <h2 class="govuk-heading-m govuk-!-font-size-27">Training with a disability</h2>
+  {% include "_includes/review/disability.njk" %}
+
   <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
   <h3 class="govuk-heading-m">Degree(s)</h3>
   {% include "_includes/review/degrees.njk" %}

--- a/app/views/application/submitted.njk
+++ b/app/views/application/submitted.njk
@@ -40,6 +40,9 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27">Volunteering with children and young people</h2>
   {% include "_includes/review/school-experience.njk" %}
 
+  <h2 class="govuk-heading-m govuk-!-font-size-27">Training with a disability</h2>
+  {% include "_includes/review/disability.njk" %}
+
   <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
   <h3 class="govuk-heading-m">Degree(s)</h3>
   {% include "_includes/review/degrees.njk" %}


### PR DESCRIPTION
First pass at adding a disabilities section. Content is largely lifted from https://getintoteaching.education.gov.uk/train-to-teach-with-a-disability

Field asking for details about disability probably needs some guidance, and if so would live on a subsequent page.

![localhost_3000_application_SZG67_disability_referrer=_application_SZG67_disabilities_review](https://user-images.githubusercontent.com/319055/67025672-55999a00-f0fe-11e9-86e7-080827a274e7.png)

![Screen Shot 2019-10-17 at 16 51 50](https://user-images.githubusercontent.com/319055/67025735-7104a500-f0fe-11e9-8380-cda257ccbfd9.png)
