### PR TITLE
Send users straight into the add course flow

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -32,7 +32,8 @@ module.exports = router => {
   // Generate new applicationID and redirect to that application
   router.get('/application/start', (req, res) => {
     var code = createNewApplication(req)
-    res.redirect(`/application/${code}`)
+    req.session.data.applications[code].welcomeFlow = true
+    res.redirect(`/application/${code}/choices/add`)
   })
 
   router.get('/application/start/choice', (req, res) => {
@@ -50,6 +51,7 @@ module.exports = router => {
 
   // Render application page
   router.all('/application/:applicationId', (req, res) => {
+    req.session.data.applications[req.params.applicationId].welcomeFlow = false
     res.render('application/index')
   })
 

--- a/app/routes/application/choices.js
+++ b/app/routes/application/choices.js
@@ -46,6 +46,11 @@ module.exports = router => {
       started: true
     }
 
+    // Already made one choice, second choice shouldn't be in welcome flow
+    if (data.applications[applicationId].choices && Object.entries(data.applications[applicationId].choices).length > 0) {
+      req.session.data.applications[applicationId].welcomeFlow = false
+    }
+
     res.redirect(`/application/${applicationId}/choices/${choiceId}/found`)
   })
 

--- a/app/views/application/choices/find.njk
+++ b/app/views/application/choices/find.njk
@@ -10,8 +10,13 @@
   {{ govukButton({
     text: "Start now",
     href: data['find_url'],
-    isStartButton: true
+    isStartButton: true,
+    classes: "govuk-!-margin-bottom-5"
   }) }}
 
-  <p><a href="/application/{{ applicationId }}">Return to your application</a></p>
+  {% if not applicationValue('welcomeFlow') %}
+    <p>
+      <a href="/application/{{ applicationId }}">Return to your application</a>
+    </p>
+  {% endif %}
 {% endblock %}

--- a/app/views/application/choices/found.njk
+++ b/app/views/application/choices/found.njk
@@ -8,7 +8,12 @@
   {% set title = "Have you chosen a course to apply to?" %}
 {% endif %}
 {% set formaction = paths.current %}
-{% block pageNavigation %}{{ govukBackLink({ href: paths.back }) }}{% endblock %}
+
+{% block pageNavigation %}
+  {% if not applicationValue('welcomeFlow') %}
+    {{ govukBackLink({ href: paths.back }) }}
+  {% endif %}
+{% endblock %}
 
 {% block primary %}
   {% if hasCourseFromFind %}

--- a/app/views/application/choices/index.njk
+++ b/app/views/application/choices/index.njk
@@ -19,18 +19,22 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">You can apply for up to 3 courses at this stage of your application.</p>
-  <p class="govuk-body">Once you’ve chosen your courses, you’ll be able to tailor your application to suit different courses and training providers.</p>
-  <p class="govuk-body">Bear in mind that not all courses and training providers are signed up to GOV.UK Apply.</p>
-  <p class="govuk-body">If you choose a course that isn’t signed up to the service, you’ll be directed back to UCAS to continue your application.</p>
-
   {% if choices %}
     {% set referrer = applicationPath + "/choices" %}
     {% set review = true %}
     {% include "_includes/review/choices.njk" %}
     {% if choices | length < 3 %}
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-heading-m">Apply for up to 3 courses</h2>
+          <p class="govuk-body">You can apply for up to 3 courses at this stage of your application.</p>
+          {# <p class="govuk-body">Once you’ve chosen your courses, you’ll be able to tailor your application to suit different courses and training providers.</p> #}
+          <p class="govuk-body">Not all courses and training providers are signed up to GOV.UK Apply. If you choose a course that isn’t signed up to the service, you’ll be directed to UCAS to continue your application.</p>
+        </div>
+      </div>
+
       {{ govukButton({
-        classes: "govuk-button--secondary",
+        classes: "govuk-button--secondary govuk-!-margin-bottom-9",
         text: "Add another course",
         href: applicationPath + "/choices/add"
       }) }}

--- a/app/views/application/choices/index.njk
+++ b/app/views/application/choices/index.njk
@@ -6,15 +6,17 @@
 {% set title = "Course choices" %}
 
 {% block pageNavigation %}
-  {% if referrer %}
-    {{ govukBackLink({
-      href: referrer
-    }) }}
-  {% else %}
-    {{ govukBackLink({
-      href: "/application/" + applicationId,
-      text: "Back to application"
-    }) }}
+  {% if not applicationValue('welcomeFlow') %}
+    {% if referrer %}
+      {{ govukBackLink({
+        href: referrer
+      }) }}
+    {% else %}
+      {{ govukBackLink({
+        href: "/application/" + applicationId,
+        text: "Back to application"
+      }) }}
+    {% endif %}
   {% endif %}
 {% endblock %}
 

--- a/app/views/application/choices/pick.njk
+++ b/app/views/application/choices/pick.njk
@@ -62,10 +62,13 @@
     </ul>
     <hr class="govuk-section-break govuk-section-break--l">
     <p class="govuk-body"><a href="https://2020.teachertraining.apply.ucas.com/apply/student/login.do" class="govuk-button govuk-!-margin-bottom-0">Apply on UCAS</a></p>
-    <p class="govuk-body">or</p>
-    <p class="govuk-body">
-      <a href="{{ applicationPath }}" class="govuk-button govuk-button--secondary">Return to your application</a>
-    </p>
+
+    {% if not applicationValue('welcomeFlow') %}
+      <p class="govuk-body">or</p>
+      <p class="govuk-body">
+        <a href="{{ applicationPath }}" class="govuk-button govuk-button--secondary">Return to your application</a>
+      </p>
+    {% endif %}
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
We want users to add a course straight away, or fail fast – ie leave for UCAS if we can't accommodate their choice.

We don't want to risk users completing an application form, then not being able to apply to the course they want to.

Introduces concept of a welcome flow.