### PR TITLE
Add an account created page

### DIFF
--- a/app/routes/email.js
+++ b/app/routes/email.js
@@ -17,4 +17,9 @@ module.exports = router => {
       action: req.params.action
     })
   })
+
+  // Account created
+  router.get('/account/account-created', (req, res) => {
+    res.render('account/account-created')
+  })
 }

--- a/app/views/account/account-created.njk
+++ b/app/views/account/account-created.njk
@@ -1,9 +1,9 @@
 {% extends "_content.njk" %}
 
-{% set title = "Welcome to Apply for teacher training" %}
+{% set title = "Account created" %}
 
 {% block primary %}
-  <p>Thank you for confirming your email address.</p>
+  <p>You have successfully created an account on GOV.UK Apply for teacher training.</p>
   <p>Your information will now be stored when you save and continue, so you can complete the application in your own time.</p>
   <p>We've also sent you a welcome email with a link to the service, to help you find it when you need to.</p>
   <p>For security, each time you return, you’ll be asked to sign in using your email address.</p>

--- a/app/views/account/account-created.njk
+++ b/app/views/account/account-created.njk
@@ -1,11 +1,12 @@
 {% extends "_content.njk" %}
 
-{% set title = "Account created" %}
+{% set title = "Welcome to Apply for teacher training" %}
 
 {% block primary %}
-  <p>You have successfully created an account on GOV.UK Apply for teacher training.</p>
-  <p>Your information will be saved as you enter it. You can leave and return to the service as often as you like to complete the application in your own time.</p>
-  <p>For security, each time you return to the service you’ll be asked to sign in using your email.</p>
+  <p>Thank you for confirming your email address.</p>
+  <p>Your information will now be stored when you save and continue, so you can complete the application in your own time.</p>
+  <p>We've also sent you a welcome email with a link to the service, to help you find it when you need to.</p>
+  <p>For security, each time you return, you’ll be asked to sign in using your email address.</p>
 
   <hr class="govuk-section-break govuk-section-break--m">
   {{ govukButton({

--- a/app/views/account/account-created.njk
+++ b/app/views/account/account-created.njk
@@ -1,0 +1,15 @@
+{% extends "_content.njk" %}
+
+{% set title = "Account created" %}
+
+{% block primary %}
+  <p>You have successfully created an account on GOV.UK Apply for teacher training.</p>
+  <p>Your information will be saved as you enter it. You can leave and return to the service as often as you like to complete the application in your own time.</p>
+  <p>For security, each time you return to the service you’ll be asked to sign in using your email.</p>
+
+  <hr class="govuk-section-break govuk-section-break--m">
+  {{ govukButton({
+    text: "Continue",
+    href: "/application/start"
+  }) }}
+{% endblock %}

--- a/app/views/account/check-email.njk
+++ b/app/views/account/check-email.njk
@@ -4,8 +4,8 @@
 {% set isSignedOut = true %}
 
 {% block primary %}
-  <p><a class="app-hidden-link" href="/email/confirm-address/{{ action }}">We’ve sent an email to {{ data.account.email }}</a>.</p>
+  <p class="govuk-body-l"><a class="app-hidden-link" href="/email/confirm-address/{{ action }}">We’ve sent an email to {{ data.account.email }}</a>.</p>
 
-  <p>Click on the link to confirm your {{ "new " if action == "change-email-address" }}address and return to this service.</p>
-  <p class="govuk-body">If our email doesn’t arrive within 5 minutes, check your spam and trash folder, or <a href="/account/create-account">try again</a>.</p>
+  <p class="govuk-body-l">Click on the link to confirm your {{ "new " if action == "change-email-address" }}address and return to this service.</p>
+  <p class="govuk-body-l">If our email doesn’t arrive within 5 minutes, check your spam and trash folder, or <a href="/account/create-account">try again</a>.</p>
 {% endblock %}

--- a/app/views/account/check-email.njk
+++ b/app/views/account/check-email.njk
@@ -4,6 +4,8 @@
 {% set isSignedOut = true %}
 
 {% block primary %}
-  <p class="govuk-body-l"><a class="app-hidden-link" href="/email/confirm-address/{{ action }}">We’ve sent you an email</a>. Click on the link to confirm your {{ "new " if action == "change-email-address" }}address and return to this service.</p>
+  <p><a class="app-hidden-link" href="/email/confirm-address/{{ action }}">We’ve sent an email to {{ data.account.email }}</a>.</p>
+
+  <p>Click on the link to confirm your {{ "new " if action == "change-email-address" }}address and return to this service.</p>
   <p class="govuk-body">If our email doesn’t arrive within 5 minutes, check your spam and trash folder, or <a href="/account/create-account">try again</a>.</p>
 {% endblock %}

--- a/app/views/account/create-account.njk
+++ b/app/views/account/create-account.njk
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body-l">You'll then be able to save and return to your application.</p>
+  <p class="govuk-body-l">You’ll then be able to save and return to your application.</p>
 
   {{ govukInput({
     label: {

--- a/app/views/email/application-submitted.njk
+++ b/app/views/email/application-submitted.njk
@@ -29,7 +29,7 @@
   <p class="govuk-body">We will send a reminder email to your referees after 5 days. If we haven’t heard back from them after 10 days, or they refuse to give a reference, we’ll get back in touch with you to ask for a replacement.</p>
 
   <h3 class="govuk-heading-s">Interview</h3>
-  <p class="govuk-body">Most training providers don’t reach a decision about interview until they’ve seen references.</p>
+  <p class="govuk-body">Most training providers don’t reach a decision about your interview until they’ve seen references.</p>
 
   <h3 class="govuk-heading-s">Application decision</h3>
   <p class="govuk-body">Your training provider will respond to your application within 40 working days via email. If they decide to progress your application, they will communicate with you directly to organise an interview date and give you all the information you need.</p>

--- a/app/views/email/confirm-address.njk
+++ b/app/views/email/confirm-address.njk
@@ -13,7 +13,7 @@
   {% if action == "create-account" %}
     <h1 class="govuk-heading-m">{{ title }}</h1>
     <p class="govuk-body">Click the link below to confirm your email address and go back to the <b>{{ serviceName }}</b> service.</p>
-    <p class="govuk-body"><a href="/application/start">https://{{ serviceSlug }}.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
+    <p class="govuk-body"><a href="/account/account-created">https://{{ serviceSlug }}.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
     <p class="govuk-body">You will then be able to save and return to your application.</p>
     <p class="govuk-body">By signing in, you also agree to the <a href="/terms-conditions">terms and conditions</a> of the {{ serviceName }} service.
   {% elif action == "change-email-address" %}

--- a/app/views/email/confirm-address.njk
+++ b/app/views/email/confirm-address.njk
@@ -12,7 +12,7 @@
 {% block content %}
   {% if action == "create-account" %}
     <h1 class="govuk-heading-m">{{ title }}</h1>
-    <p class="govuk-body">Click the link below to confirm your email address and go back to the <b>{{ serviceName }}</b> service.</p>
+    <p class="govuk-body">Click the link below to confirm your email address, create an account and go back to the <b>{{ serviceName }}</b> service.</p>
     <p class="govuk-body"><a href="/account/account-created">https://{{ serviceSlug }}.service.gov.uk/verify?token=wCsix7SbCR9e9Pv2SQ3Q</a></p>
     <p class="govuk-body">You will then be able to save and return to your application.</p>
     <p class="govuk-body">By signing in, you also agree to the <a href="/terms-conditions">terms and conditions</a> of the {{ serviceName }} service.

--- a/app/views/email/welcome.njk
+++ b/app/views/email/welcome.njk
@@ -1,6 +1,6 @@
 {% extends "_email.njk" %}
 
-{% set title = "Thank you for using " + serviceName %}
+{% set title = "Welcome to" + serviceName %}
 {% set to = data.account.email %}
 
 {% block content %}


### PR DESCRIPTION
Users are not sure that they've created an account, and are unsure how to return.
Include an explicit confirmation step.

Part of https://trello.com/c/dgQjwXb2/220-save-and-return