### PR TITLE
Remove start page from find flow

### DIFF
--- a/app/routes/apply.js
+++ b/app/routes/apply.js
@@ -38,7 +38,7 @@ module.exports = router => {
         courseCode
       }
 
-      res.redirect('/') // Go to Apply
+      res.redirect('/account/eligibility') // Go to Apply
     }
   })
 

--- a/app/views/account/account-created.njk
+++ b/app/views/account/account-created.njk
@@ -5,7 +5,7 @@
 {% block primary %}
   <p>You have successfully created an account on GOV.UK Apply for teacher training.</p>
   <p>Your information will now be stored when you save and continue, so you can complete the application in your own time.</p>
-  <p>We've also sent you a welcome email with a link to the service, to help you find it when you need to.</p>
+  <p>We’ve also sent you a welcome email with a link to the service, to help you find it when you need to.</p>
   <p>For security, each time you return, you’ll be asked to sign in using your email address.</p>
 
   <hr class="govuk-section-break govuk-section-break--m">

--- a/app/views/application/choices/found.njk
+++ b/app/views/application/choices/found.njk
@@ -3,7 +3,7 @@
 {% if hasCourseFromFind %}
   {% set provider = providers[data.course_from_find.providerCode] %}
   {% set course = provider.courses[data.course_from_find.courseCode] %}
-  {% set title = "You’ve selected a course" %}
+  {% set title = "You selected a course" %}
 {% else %}
   {% set title = "Have you chosen a course to apply to?" %}
 {% endif %}
@@ -17,8 +17,20 @@
 
 {% block primary %}
   {% if hasCourseFromFind %}
+    {% set courseHtml %}
+      <a href="{{ data.find_url }}/course/T92/X130" target="_blank" class="govuk-!-font-weight-bold" style="text-decoration: none">
+        <span class="govuk-!-font-size-19">
+          {{ provider.name }}
+        </span><br>
+        <span class="search-result-link-name govuk-!-font-size-24" style="text-decoration: underline">
+          {{ course.name_and_code }}
+        </span>
+      </a>
+    {% endset %}
+
+
     {{ govukInsetText({
-        html: "<span class='govuk-!-font-weight-bold'>" + provider.name_and_code + "</span><br />" + course.name_and_code,
+        html: courseHtml,
         classes: "govuk-!-margin-top-0"
     }) }}
 


### PR DESCRIPTION
As per https://docs.google.com/drawings/d/1d30V3qtVYQNL_gWIMuGjgjm2doWMIDyIyYWchIKnPe8/edit

- Remove start page from flow
- Tweak title of found course page
- Use Find course styles to indicate which course was chosen
- Link to course to allow double checking (we saw a user that was uncertain about which course they’d clicked – https://lookback.io/watch/pJKvbAXRyrbweqCHP?t=30m41.91s)

![Screen Shot 2019-10-22 at 16 29 45](https://user-images.githubusercontent.com/319055/67302696-2d88ad00-f4e9-11e9-9630-2227cd4d6b9c.png)
