### PR TITLE
Add Apply variant links

### DIFF
--- a/app/views/_layout.njk
+++ b/app/views/_layout.njk
@@ -121,7 +121,16 @@
       } if not urStudy, {
         href: "/admin/clear-data",
         text: "Clear data"
-      } if not urStudy]
+      } if not urStudy, {
+        href: "/apply/" + providerCode + "/" + courseCode + "?dualrunning=true&variant=1",
+        text: "v1"
+      } if providerCode and courseCode, {
+        href: "/apply/" + providerCode + "/" + courseCode + "?dualrunning=true&variant=2",
+        text: "v2"
+      } if providerCode and courseCode, {
+        href: "/apply/" + providerCode + "/" + courseCode + "?dualrunning=true&variant=3",
+        text: "v3"
+      } if providerCode and courseCode]
     }
   }) }}
 {% endblock %}


### PR DESCRIPTION
Shows links to the different variants in the footer for those pages which include `providerCode` and `courseCode` variables to a template (i.e. pages in the dual running and course selection journeys).

![Screenshot 2019-11-04 at 17 02 24](https://user-images.githubusercontent.com/813383/68141180-f40e6380-ff24-11e9-9e37-465f23bd3ac0.png)
