### PR TITLE
Editing contact details at any time

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -19,6 +19,7 @@ module.exports = {
     nationality: process.env.MVP !== 'true',
     referee_types: process.env.MVP !== 'true',
     self_amend: process.env.MVP !== 'true',
+    self_amend_contact_details: process.env.MVP !== 'true',
     self_withdraw: process.env.MVP !== 'true'
   },
   applications: (process.env.PRODUCTION === 'true') ? {} : testData

--- a/app/routes/application/contact-details.js
+++ b/app/routes/application/contact-details.js
@@ -11,7 +11,7 @@ module.exports = router => {
     const international_address_feature_enabled = req.session.data.flags.international_address
 
     if (!international_address_feature_enabled) {
-      res.redirect(`/application/${applicationId}/contact-details/where-do-you-live/answer`)
+      res.redirect(`/application/${applicationId}/contact-details/where-do-you-live/answer?referrer=${referrer}`)
     } else {
       res.render('application/contact-details/where-do-you-live', {
         referrer
@@ -21,6 +21,7 @@ module.exports = router => {
 
   // Address type answer branching
   router.all('/application/:applicationId/contact-details/where-do-you-live/answer', (req, res) => {
+    const referrer = req.query.referrer
     const applicationId = req.params.applicationId
     const applicationData = req.session.data.applications[applicationId]
     const location = applicationData['contact-details']['address-type']
@@ -29,12 +30,12 @@ module.exports = router => {
 
     if (location === 'domestic' || !international_address_feature_enabled) {
       if (address_lookup_feature_enabled) {
-        res.redirect(`/application/${applicationId}/contact-details/lookup-address`)
+        res.redirect(`/application/${applicationId}/contact-details/lookup-address?referrer=${referrer}`)
       } else {
-        res.redirect(`/application/${applicationId}/contact-details/uk-address`)
+        res.redirect(`/application/${applicationId}/contact-details/uk-address?referrer=${referrer}`)
       }
     } else {
-      res.redirect(`/application/${applicationId}/contact-details/international-address`)
+      res.redirect(`/application/${applicationId}/contact-details/international-address?referrer=${referrer}`)
     }
   })
 

--- a/app/views/_includes/need-help.njk
+++ b/app/views/_includes/need-help.njk
@@ -1,4 +1,5 @@
 {{ appRelated({
+  name: "help",
   title: "Need help?",
   content: {
     html: "Call <a href=\"https://getintoteaching.education.gov.uk/\">Get into Teaching</a> on Freephone 0800 389 2500 or chat to an adviser using their <a href=\"https://getintoteaching.education.gov.uk/lp/live-chat\">online chat service</a> between 8am and 8pm, Monday to Friday"

--- a/app/views/_includes/review/contact-details.njk
+++ b/app/views/_includes/review/contact-details.njk
@@ -1,26 +1,26 @@
 {% set applicationPath = "/application/" + applicationId %}
 {% set addressHtml -%}
-  {%- if applicationValue(["contact-details", "address"]) -%}
-    {%- if applicationValue(["contact-details", "address", "street-address"]) -%}
-      {{ applicationValue(["contact-details", "address", "street-address"]) }}
+  {%- if contactDetails.address -%}
+    {%- if contactDetails.address["street-address"] -%}
+      {{ contactDetails.address["street-address"] }}
     {%- else -%}
-      {%- if applicationValue(["contact-details", "address", "line1"]) -%}
-        {{ applicationValue(["contact-details", "address", "line1"]) }}<br>
+      {%- if contactDetails.address.line1 -%}
+        {{ contactDetails.address.line1 }}<br>
       {%- endif -%}
-      {%- if applicationValue(["contact-details", "address", "line2"]) -%}
-        {{ applicationValue(["contact-details", "address", "line2"]) }}<br>
+      {%- if contactDetails.address.line2 -%}
+        {{ contactDetails.address.line2 }}<br>
       {%- endif -%}
-      {%- if applicationValue(["contact-details", "address", "level2"]) -%}
-        {{ applicationValue(["contact-details", "address", "level2"]) }}<br>
+      {%- if contactDetails.address.level2 -%}
+        {{ contactDetails.address.level2 }}<br>
       {%- endif -%}
-      {%- if applicationValue(["contact-details", "address", "level1"]) -%}
-        {{ applicationValue(["contact-details", "address", "level1"]) }}<br>
+      {%- if contactDetails.address.level1 -%}
+        {{ contactDetails.address.level1 }}<br>
       {%- endif -%}
-      {%- if applicationValue(["contact-details", "address", "postal-code"]) -%}
-        {{ applicationValue(["contact-details", "address", "postal-code"]) }}<br>
+      {%- if contactDetails.address["postal-code"] -%}
+        {{ contactDetails.address["postal-code"] }}<br>
       {%- endif -%}
-      {%- if applicationValue(["contact-details", "address", "country"]) -%}
-        {{ applicationValue(["contact-details", "address", "country"]) }}
+      {%- if contactDetails.address.country -%}
+        {{ contactDetails.address.country }}
       {%- endif -%}
     {%- endif -%}
   {%- else -%}
@@ -35,7 +35,7 @@
         text: "Phone number"
       },
       value: {
-        text: applicationValue(["contact-details", "phone-number"]) or "Not entered"
+        text: contactDetails["phone-number"] or "Not entered"
       },
       actions: {
         items: [{
@@ -76,7 +76,7 @@
   }) }}
 {% endset %}
 
-{% if applicationValue("contact-details") %}
+{% if contactDetails %}
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     html: contactDetailsHtml

--- a/app/views/application/contact-details/review.njk
+++ b/app/views/application/contact-details/review.njk
@@ -13,6 +13,7 @@
 {% endblock %}
 
 {% block primary %}
+  {% set contactDetails = applicationValue(["contact-details"]) %}
   {% include "_includes/review/contact-details.njk" %}
   {{ govukButton({
     text: "Continue",

--- a/app/views/application/edit.njk
+++ b/app/views/application/edit.njk
@@ -19,12 +19,12 @@
     <h2 class="govuk-heading-m">References</h2>
     <p class="govuk-body">You can’t edit your choice of referees unless they refuse to give a reference. We’ll email you if this happens, so you can put forward a replacement referee.</p>
     <h2 class="govuk-heading-m">Contact details</h2>
-    <p class="govuk-body">You can edit your contact details throughout the application process. Sign into your account and visit <a href="/applications">Application dashboard.</a></p>
+    <p class="govuk-body">You can update your contact details at any point during the application process. Sign into your account and visit <a href="/applications">Application dashboard.</a></p>
     {{ govukButton({
       text: "Continue"
     }) }}
   {% else %}
-    <p class="govuk-body">To edit, you'll need to email us at <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>, explaining which changes you'd like to make.</p>
+    <p class="govuk-body">To edit, you’ll need to email us at <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>, explaining which changes you’d like to make.</p>
     <p class="govuk-body">We can only edit your application once.</p>
     <h2 class="govuk-heading-m">Course choice</h2>
     <p class="govuk-body">We can change your choice of training provider, course or location within the 5 working day editing period.</p>
@@ -33,6 +33,6 @@
     <h2 class="govuk-heading-m">References</h2>
     <p class="govuk-body">We can’t edit your choice of referees unless they refuse to give a reference. We’ll email you if this happens, so you can put forward a replacement referee.</p>
     <h2 class="govuk-heading-m">Contact details</h2>
-    <p class="govuk-body">You can update your contact details throughout the application process, by emailing us at <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+    <p class="govuk-body">You can update your contact details at any point during the application process. To do this, email us at <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
   {% endif %}
 {% endblock %}

--- a/app/views/application/references/review.njk
+++ b/app/views/application/references/review.njk
@@ -3,9 +3,9 @@
 {% set applicationPath = "/application/" + applicationId %}
 {% set title = "References" %}
 {% set referrer = applicationPath + "/references/review" %}
+
 {# You can’t amend your referees once application has been submitted #}
 {% set canAmend = true if not hasSubmittedApplications() %}
-{% set references = applicationValue(["referees"]) %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -15,6 +15,7 @@
 {% endblock %}
 
 {% block primary %}
+  {% set references = applicationValue(["referees"]) %}
   {% include "_includes/review/references.njk" %}
   {% if not applicationValue(["referees", "second"]) %}
     {{ govukButton({
@@ -22,9 +23,7 @@
       href: "/application/" + applicationId + "/references/" + ("type" if data.flags.referee_types else "details") + "/second?referrer=" + referrer,
       classes: "govuk-button--secondary"
     }) }}
-
     <p>or</p>
-
     {{ govukButton({
       text: "Continue without adding second referee",
       href: applicationPath

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -2,12 +2,9 @@
 
 {% set applicationPath = "/application/" + applicationId %}
 {% set status = applicationValue(["status"]) %}
-{% set choices = applicationValue(["choices"]) | toArray %}
-{% set references = applicationValue(["referees"]) %}
 {% set title = "Review your application" %}
-{% set showChoiceStatus = false %}
-{% set canAmend = true %}
 {% set referrer = applicationPath + "/review" %}
+{% set canAmend = true %}
 
 {# Skip equality monitoring questions if amending application #}
 {% set nextHref = applicationPath + ("/submit" if applicationValue(["status"]) == "amending" else "/equality-monitoring") %}
@@ -24,8 +21,11 @@
     text: "Please review your changes carefully before you resubmit. Your application can only be resubmitted once.",
     iconFallbackText: "Warning"
   }) if status == "amending" }}
+
   <h2 class="govuk-heading-m govuk-!-font-size-27">Course choices</h2>
+  {% set choices = applicationValue(["choices"]) | toArray %}
   {% if choices %}
+    {% set showChoiceStatus = false %}
     {% include "_includes/review/choices.njk" %}
   {% else %}
     {{ govukButton({
@@ -40,6 +40,7 @@
   {% include "_includes/review/personal-details.njk" %}
 
   <h3 class="govuk-heading-m">Contact details</h3>
+  {% set contactDetails = applicationValue(["contact-details"]) %}
   {% include "_includes/review/contact-details.njk" %}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
@@ -79,6 +80,7 @@
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
   {# You can’t change your referees once application has been submitted #}
+  {% set references = applicationValue(["referees"]) %}
   {% include "_includes/review/references.njk" %}
 
   {{ govukButton({

--- a/app/views/application/submitted.njk
+++ b/app/views/application/submitted.njk
@@ -2,12 +2,9 @@
 
 {% set applicationPath = "/application/" + applicationId %}
 {% set status = applicationValue(["status"]) %}
-{% set choices = applicationValue(["choices"]) | toArray %}
-{% set references = applicationValue(["referees"]) %}
 {% set title = "Your submitted application" %}
-{% set showChoiceStatus = false %}
-{% set canAmend = false %}
 {% set referrer = applicationPath + "/review" %}
+{% set canAmend = false %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -30,6 +27,8 @@
   }) }}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">Course choices</h2>
+  {% set choices = applicationValue(["choices"]) | toArray %}
+  {% set showChoiceStatus = false %}
   {% include "_includes/review/choices.njk" %}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
@@ -37,6 +36,7 @@
   {% include "_includes/review/personal-details.njk" %}
 
   <h3 class="govuk-heading-m">Contact details</h3>
+  {% set contactDetails = applicationValue(["contact-details"]) %}
   {% include "_includes/review/contact-details.njk" %}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
@@ -75,5 +75,6 @@
   {% include "_includes/review/interview.njk" %}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
+  {% set references = applicationValue(["referees"]) %}
   {% include "_includes/review/references.njk" %}
 {% endblock %}

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -100,8 +100,25 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">References</h2>
   {% set references = application.referees %}
   {% include "_includes/review/references.njk" %}
+
+  {% if data.flags.self_amend_contact_details %}
+    {# Contact details #}
+    <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Contact details</h2>
+    <p class="govuk-body">You can update your contact details at any point during the application process.</p>
+    {% set contactDetails = application["contact-details"] %}
+    {% set canAmend = true %}
+    {% include "_includes/review/contact-details.njk" %}
+  {% endif %}
 {% endblock %}
 
 {% block secondary %}
   {% include "_includes/need-help.njk" %}
+  {% if not data.flags.self_amend_contact_details %}
+    {{ appRelated({
+      title: "Updating your contact details",
+      content: {
+        html: "You can update your contact details at any point during the application process. To do this, email us at <a href=\"mailto:becomingateacher@digital.education.gov.uk\">becomingateacher<wbr>@digital.education.gov.uk</a>."
+      }
+    }) }}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
As a general point, I think we should show the ability to edit your contact details regardless of application phase, i.e. even during the amendment period. Thought being, if someone wants to edit their address, doing so shouldn’t mean they then lose the ability to resubmit an edited application should they then wish to make further changes (within the amendment period).

## For MVP

We include an email link in the sidebar:

![MVP](https://user-images.githubusercontent.com/813383/68674412-bd9c9e00-054d-11ea-9ec4-3e11b1b79a89.png)

## Full-fat

We show your contact details at the bottom of the page, and allow you to edit fields individually. This essentially works the same as it does when completing your application. Nice!

![Full-fat](https://user-images.githubusercontent.com/813383/68674413-bf666180-054d-11ea-806a-32c703453928.png)
