### PR TITLE
Ask if want to add other qualifications

### DIFF
--- a/app/routes/application/other-qualifications.js
+++ b/app/routes/application/other-qualifications.js
@@ -4,6 +4,21 @@ const utils = require('./../../utils')
  * Application: Other relevant qualifications routes
  */
 module.exports = router => {
+  // Other qualifications answer branching
+  router.post('/application/:applicationId/other-qualifications/answer', (req, res) => {
+    const applicationId = req.params.applicationId
+    const applicationData = utils.applicationData(req)
+    const include = applicationData['include-other-qualifications']
+    applicationData.completed = applicationData.completed || {}
+
+    if (include === 'no') {
+      applicationData.completed['other-qualifications'] = true
+      res.redirect(`/application/${applicationId}`)
+    } else {
+      res.redirect(`/application/${applicationId}/other-qualifications/add`)
+    }
+  })
+
   // Generate new id and redirect to that qualification
   router.get('/application/:applicationId/other-qualifications/add', (req, res) => {
     const id = utils.generateRandomString()
@@ -13,7 +28,16 @@ module.exports = router => {
   // Render review page
   // Note: Must be defined before next route declaration
   router.get('/application/:applicationId/other-qualifications/review', (req, res) => {
-    res.render('application/other-qualifications/review')
+    const applicationData = utils.applicationData(req)
+    const completed = applicationData.completed['other-qualifications']
+    const qualifications = utils.toArray(applicationData['other-qualifications'])
+
+    // If previously opted out of question, ask question again
+    if (completed && !qualifications.length) {
+      res.redirect(`/application/${req.params.applicationId}/other-qualifications`)
+    } else {
+      res.render('application/other-qualifications/review')
+    }
   })
 
   // Render details page
@@ -21,7 +45,7 @@ module.exports = router => {
     const id = req.params.id
     const referrer = req.query.referrer
 
-    res.render('application/other-qualifications/index', {
+    res.render('application/other-qualifications/qualification', {
       formaction: referrer || `/application/${req.params.applicationId}/other-qualifications/review`,
       id,
       referrer

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -134,7 +134,7 @@
       } if applicationValue(["gcse", "science"])
     } if hasPrimaryChoices() or applicationValue(["gcse", "science"]), {
       text: "Other relevant academic and non-academic qualifications",
-      href: applicationPath + "/other-qualifications" + ("/review" if applicationValue(["other-qualifications"]) else "/add"),
+      href: applicationPath + "/other-qualifications" + ("/review" if applicationValue(["other-qualifications"])),
       id: "other-qualifications",
       tag: {
         classes: tagClass,

--- a/app/views/application/other-qualifications/index.njk
+++ b/app/views/application/other-qualifications/index.njk
@@ -1,7 +1,7 @@
 {% extends "_form.njk" %}
-
 {% set applicationPath = "/application/" + applicationId %}
 {% set title = "Other relevant qualifications" %}
+{% set formaction = applicationPath + "/other-qualifications/answer" %}
 
 {% block pageNavigation %}
   {% if referrer %}
@@ -17,103 +17,28 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">Enter your other qualifications as completely as you can, including all your GCSEs, A levels, and undergraduate and postgraduate degrees.</p>
-  <p class="govuk-body">You should also tell us about your vocational, practical and creative qualifications.</p>
-
-  {{ govukInput({
-    label: {
-      text: "Type of qualification",
-      classes: "govuk-label--m"
-    },
-    hint: {
-      text: "For example, GCSE, A level, BTEC, NVQ or non-UK other, please specify"
-    }
-  } | decorateApplicationAttributes(["other-qualifications", id, "type"])) }}
-
-  {{ govukInput({
-    label: {
-      text: "Subject",
-      classes: "govuk-label--m"
-    }
-  } | decorateApplicationAttributes(["other-qualifications", id, "subject"])) }}
-
-  {{ govukInput({
-    label: {
-      text: "Institution where you studied",
-      classes: "govuk-label--m"
-    }
-  } | decorateApplicationAttributes(["other-qualifications", id, "org"])) }}
-
-  {% set internationalConditionalHtml %}
-    {{ appAutocomplete({
-      label: {
-        text: "In which country is your institution based?"
-      },
-      items: countries
-    } | decorateApplicationAttributes(["other-qualifications", id, "country"])) }}
-  {% endset %}
+  <p class="govuk-body">Providers use information about your other qualifications to assess your academic ability and the broader contribution you can make to a school.</p>
+  <p class="govuk-body">You can include your GCSEs, A levels and vocational, practical and creative qualifications.</p>
+  <p class="govuk-body">Undergraduate and postgraduate degrees should be included in the ‘Degree’ section.</p>
 
   {{ govukRadios({
     fieldset: {
+      classes: "govuk-!-margin-top-6",
       legend: {
-        text: "This institution is based:"
+        text: "Would you like to add other relevant qualifications?",
+        classes: "govuk-fieldset__legend--m"
       }
     },
     items: [{
-      value: "domestic",
-      text: "In the UK"
+      value: "yes",
+      text: "Yes"
     }, {
-      value: "international",
-      text: "Outside the UK",
-      conditional: {
-        html: internationalConditionalHtml
-      }
+      value: "no",
+      text: "No"
     }]
-  } | decorateApplicationAttributes(["other-qualifications", id, "provenance"])) }}
-
-  {{ govukInput({
-    label: {
-      text: "Grade",
-      classes: "govuk-label--m"
-    },
-    classes: "govuk-input--width-10"
-  } | decorateApplicationAttributes(["other-qualifications", id, "grade"])) }}
-
-  {{ govukInput({
-    label: {
-      text: "Year qualification was awarded",
-      classes: "govuk-label--m"
-    },
-    classes: "govuk-input--width-4"
-  } | decorateApplicationAttributes(["other-qualifications", id, "year"])) }}
-
-  {# Only show ‘Add another…’ button if:
-      * not editing an existing item
-      * not referred from a review page (which also has an ‘Add another…’ button)
-  #}
-  {% if action != "edit" and not referrer %}
-    {{ govukButton({
-      text: "Save and add another qualification",
-      classes: "govuk-button--secondary",
-      attributes: {
-        formaction: applicationPath + "/other-qualifications/add"
-      }
-    }) }}
-
-    <p class="govuk-body">or</p>
-  {% endif %}
+  } | decorateApplicationAttributes(["include-other-qualifications"])) }}
 
   {{ govukButton({
-    text: "Save and continue"
+    text: "Continue"
   }) }}
-{% endblock %}
-
-{% block pageScripts %}
-  <script src="/public/javascripts/autocomplete.min.js"></script>
-  <script>
-    accessibleAutocomplete.enhanceSelectElement({
-      defaultValue: '{{ valueOrPreviousQualificationValue(["other-qualifications", id, "country"]) }}',
-      selectElement: document.querySelector('#other-qualifications-{{ id }}-country')
-    })
-  </script>
 {% endblock %}

--- a/app/views/application/other-qualifications/qualification.njk
+++ b/app/views/application/other-qualifications/qualification.njk
@@ -1,0 +1,117 @@
+{% extends "_form.njk" %}
+
+{% set applicationPath = "/application/" + applicationId %}
+{% set parent = "Other relevant qualifications" %}
+{% set title = "Add qualification" %}
+
+{% block pageNavigation %}
+  {% if referrer %}
+    {{ govukBackLink({
+      href: referrer
+    }) }}
+  {% else %}
+    {{ govukBackLink({
+      href: "/application/" + applicationId,
+      text: "Back to application"
+    }) }}
+  {% endif %}
+{% endblock %}
+
+{% block primary %}
+  {{ govukInput({
+    label: {
+      text: "Type of qualification",
+      classes: "govuk-label--m"
+    },
+    hint: {
+      text: "For example, GCSE, A level, BTEC, NVQ or non-UK other, please specify"
+    }
+  } | decorateApplicationAttributes(["other-qualifications", id, "type"])) }}
+
+  {{ govukInput({
+    label: {
+      text: "Subject",
+      classes: "govuk-label--m"
+    }
+  } | decorateApplicationAttributes(["other-qualifications", id, "subject"])) }}
+
+  {{ govukInput({
+    label: {
+      text: "Institution where you studied",
+      classes: "govuk-label--m"
+    }
+  } | decorateApplicationAttributes(["other-qualifications", id, "org"])) }}
+
+  {% set internationalConditionalHtml %}
+    {{ appAutocomplete({
+      label: {
+        text: "In which country is your institution based?"
+      },
+      items: countries
+    } | decorateApplicationAttributes(["other-qualifications", id, "country"])) }}
+  {% endset %}
+
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: "This institution is based:"
+      }
+    },
+    items: [{
+      value: "domestic",
+      text: "In the UK"
+    }, {
+      value: "international",
+      text: "Outside the UK",
+      conditional: {
+        html: internationalConditionalHtml
+      }
+    }]
+  } | decorateApplicationAttributes(["other-qualifications", id, "provenance"])) }}
+
+  {{ govukInput({
+    label: {
+      text: "Grade",
+      classes: "govuk-label--m"
+    },
+    classes: "govuk-input--width-10"
+  } | decorateApplicationAttributes(["other-qualifications", id, "grade"])) }}
+
+  {{ govukInput({
+    label: {
+      text: "Year qualification was awarded",
+      classes: "govuk-label--m"
+    },
+    classes: "govuk-input--width-4"
+  } | decorateApplicationAttributes(["other-qualifications", id, "year"])) }}
+
+  {# Only show ‘Add another…’ button if:
+      * not editing an existing item
+      * not referred from a review page (which also has an ‘Add another…’ button)
+  #}
+  {% if action != "edit" and not referrer %}
+    {{ govukButton({
+      text: "Save and add another qualification",
+      classes: "govuk-button--secondary",
+      attributes: {
+        formaction: applicationPath + "/other-qualifications/add"
+      }
+    }) }}
+
+    <p class="govuk-body">or</p>
+  {% endif %}
+
+  {{ govukButton({
+    text: "Save and continue"
+  }) }}
+{% endblock %}
+
+{% block pageScripts %}
+  <script src="/public/javascripts/autocomplete.min.js"></script>
+  <script>
+    accessibleAutocomplete.enhanceSelectElement({
+      defaultValue: '{{ valueOrPreviousQualificationValue(["other-qualifications", id, "country"]) }}',
+      selectElement: document.querySelector('#other-qualifications-{{ id }}-country')
+    })
+  </script>
+{% endblock %}


### PR DESCRIPTION
Currently, if you don’t want to add any other qualifications, there’s no means of saying so. This means when it comes to reviewing your answers and validating that you have completed all sections, it’s impossible to complete your application without adding a qualification. 🤪

This PR updates the design of the other qualifications section so that we ask a candidate if they want to add any other qualifications. If they select ‘No’, they are returned to the application overview and the section is marked as completed. If they click back into this section, they can select ‘Yes’ and proceed as before.

![Screenshot 2019-11-22 at 12 33 05](https://user-images.githubusercontent.com/813383/69426310-e890aa00-0d24-11ea-9e2b-194260be6c5e.png)
