### PR TITLE
Refactor reviewing and submitting incomplete application

### DIFF
--- a/app/assets/sass/components/_banner.scss
+++ b/app/assets/sass/components/_banner.scss
@@ -29,16 +29,34 @@
 
 .app-banner--success {
   border-color: govuk-colour("green");
+
+  .app-banner__icon {
+    fill: govuk-colour("green");
+  }
 }
 
 .app-banner--warning {
   border-color: govuk-colour("red");
+
+  .app-banner__icon {
+    fill: govuk-colour("red");
+  }
 
   &.app-banner--missing-section {
     .app-banner__message p {
       color: govuk-colour("red");
     }
   }
+}
+
+.app-banner__icon {
+  fill: govuk-colour("blue");
+  float: left;
+  margin-right: govuk-spacing(2);
+}
+
+.app-banner__assistive {
+  @include govuk-visually-hidden;
 }
 
 .app-banner__message {

--- a/app/assets/sass/components/_banner.scss
+++ b/app/assets/sass/components/_banner.scss
@@ -3,16 +3,42 @@
   @include govuk-responsive-padding(4);
   @include govuk-responsive-margin(8, "bottom");
   border: $govuk-border-width solid govuk-colour("blue");
+
+  &--missing-section {
+    @include govuk-responsive-margin(4, "bottom");
+
+    .app-banner__message {
+      @include govuk-media-query($from: desktop) {
+        display: flex;
+        justify-content: space-between;
+        align-items: start;
+      }
+
+      p {
+        @include govuk-typography-weight-bold;
+        color: govuk-colour("blue");
+        margin: 0;
+      }
+    }
+  }
 }
 
-.app-banner__icon {
-  fill: govuk-colour("blue");
-  float: left;
-  margin-right: govuk-spacing(2);
+.app-banner--info {
+  border-color: govuk-colour("blue");
 }
 
-.app-banner__assistive {
-  @include govuk-visually-hidden;
+.app-banner--success {
+  border-color: govuk-colour("green");
+}
+
+.app-banner--warning {
+  border-color: govuk-colour("red");
+
+  &.app-banner--missing-section {
+    .app-banner__message p {
+      color: govuk-colour("red");
+    }
+  }
 }
 
 .app-banner__message {
@@ -23,20 +49,4 @@
 
 .app-banner__message *:last-child {
   margin-bottom: 0;
-}
-
-.app-banner--success {
-  border-color: govuk-colour("green");
-
-  .app-banner__icon {
-    fill: govuk-colour("green");
-  }
-}
-
-.app-banner--warning {
-  border-color: govuk-colour("red");
-
-  .app-banner__icon {
-    fill: govuk-colour("red");
-  }
 }

--- a/app/data/dummy-application.js
+++ b/app/data/dummy-application.js
@@ -122,6 +122,10 @@ module.exports = {
     english: {
       id: 'english',
       type: 'I don’t have this qualification yet'
+    },
+    science: {
+      id: 'science',
+      type: 'I don’t have this qualification yet'
     }
   },
   'subject-knowledge': 'I pursued an MSc in Applied Physics at the University of Strathclyde and for my dissertation, I worked on the aftermath of the space radiation on bio/matter. Previously, I obtained a Bachelor of Science in Physics with an emphasis in astronomy and a minor in Mathematics at Minnesota State University Moorhead (MSUM), USA.\r\n\r\nIn my postgraduate career, I was enrolled in plasma physics courses and under the supervision of Professors Hidding and Sheng, I examined the effects of relativistic electrons at an altitude of 405 km where the International space station is on the orbit.\r\n\r\nIn addition to taking mathematics and astronomy courses in my undergraduate career, I was actively engaged in observational astronomy research throughout my undergraduate career at the Paul P. Feder Observatory at the Regional Science Center of MSUM. Under the supervision of Drs. Linda Irene Winkler, Matthew Craig, and Juan Cabanela, I performed a coarse calibration on the SBIG SGS Spectrograph using the high voltage mercury and neon light sources in the summer of 2011.\r\n\r\nMy senior year project entitled, ‘Analyzing Brightness Variations of an SX Phoenicis Star, XX Cyg,’ which involved collecting and analyzing photometric data of XX Cyg in four Johnson/Cousins Ic filters. Through my research, I found that the period of XX Cyg is 0.134868±0.000003 days. I investigated the nature of the limit cycles of algebraic systems, which involved studying autonomous nonlinear differential equations in my senior year. I found that Van der Pol Equations are used in modeling stellar pulsation mechanism.',

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -12,7 +12,7 @@ module.exports = {
   // },
   find_url: 'http://search-and-compare-ui-pr-442.herokuapp.com',
   flags: {
-    add_another: (process.env.MVP !== 'true'),
+    add_another: false,
     address_lookup: (process.env.MVP !== 'true'),
     automatic_breaks: process.env.MVP !== 'true',
     international_address: process.env.MVP !== 'true',

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -141,29 +141,36 @@ module.exports = router => {
 
   // Render review page
   router.get('/application/:applicationId/review', (req, res) => {
-    var app = utils.applicationData(req);
-    var pageObject = {};
-    var successFlash = req.flash('success');
+    var applicationData = utils.applicationData(req)
+    var pageObject = {}
+    var successFlash = req.flash('success')
 
-    if(successFlash[0] == 'submitted-incompleted-application') {
-      pageObject.errorList = [];
+    if (successFlash[0] === 'submitted-incompleted-application') {
+      pageObject.errorList = []
 
-      if(Object.keys(app.choices).length == 0) {
+      if (typeof applicationData.choices === 'undefined' || Object.keys(applicationData.choices).length === 0) {
         pageObject.errorList.push({
-          text: "Courses: section incomplete",
-          href: "#choices-error"
-        });
+          text: 'Course choices not marked as completed',
+          href: '#missing-course-choices'
+        })
       }
 
-      if(Object.keys(app['other-qualifications']).length == 0) {
+      if (typeof applicationData['school-experience'] === 'undefined' || Object.keys(applicationData['school-experience']).length === 0) {
         pageObject.errorList.push({
-          text: "Other relevant qualifications: section incomplete",
-          href: "#other-qualifications-error"
-        });
+          text: 'Volunteering with children and young people is not marked as completed',
+          href: '#missing-school-experience'
+        })
+      }
+
+      if (typeof applicationData['work-history'] === 'undefined' || Object.keys(applicationData['work-history']).length === 0) {
+        pageObject.errorList.push({
+          text: 'Work history is not marked as completed',
+          href: '#missing-work-history'
+        })
       }
     }
 
-    res.render('application/review', pageObject);
+    res.render('application/review', pageObject)
   })
 
   router.post('/application/:applicationId/review', (req, res) => {
@@ -174,10 +181,9 @@ module.exports = router => {
     // User tried to submit incomplete application
     // just checking choices are empty for now
     // to make real need to check over every section
-    if( Object.keys(applicationData.choices).length == 0 ||
-        Object.keys(applicationData['other-qualifications']).length == 0) {
-      req.flash('success', 'submitted-incompleted-application');
-      res.redirect(`/application/${req.params.applicationId}/review`);
+    if (typeof applicationData.choices === 'undefined' || Object.keys(applicationData.choices).length === 0 || Object.keys(applicationData['school-experience']).length === 0 || Object.keys(applicationData['work-history']).length === 0) {
+      req.flash('success', 'submitted-incompleted-application')
+      res.redirect(`/application/${req.params.applicationId}/review`)
     } else {
       const workHistory = applicationData['work-history']
       const schoolExperience = applicationData['school-experience']
@@ -193,7 +199,6 @@ module.exports = router => {
 
       res.render('application/review')
     }
-
   })
 
   // Render submitted page

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -10,7 +10,25 @@ function createNewApplication (req) {
 
   if (typeof data.applications[code] === 'undefined') {
     data.applications[code] = {
-      status: 'started'
+      status: 'started',
+      choices: {},
+      candidate: {},
+      'contact-details': {},
+      'reasonable-adjustments': {},
+      degree: {},
+      'other-qualifications': {},
+      gcse: {
+        maths: {},
+        english: {},
+        science: {}
+      },
+      'subject-knowledge': null,
+      'interview-choice': null,
+      interview: null,
+      'personal-statement': null,
+      'work-history': {},
+      'school-experience': {},
+      referees: {}
     }
   }
 
@@ -139,68 +157,6 @@ module.exports = router => {
     res.render('application/index')
   })
 
-  // Render review page
-  router.get('/application/:applicationId/review', (req, res) => {
-    var applicationData = utils.applicationData(req)
-    var pageObject = {}
-    var successFlash = req.flash('success')
-
-    if (successFlash[0] === 'submitted-incompleted-application') {
-      pageObject.errorList = []
-
-      if (typeof applicationData.choices === 'undefined' || Object.keys(applicationData.choices).length === 0) {
-        pageObject.errorList.push({
-          text: 'Course choices not marked as completed',
-          href: '#missing-course-choices'
-        })
-      }
-
-      if (typeof applicationData['school-experience'] === 'undefined' || Object.keys(applicationData['school-experience']).length === 0) {
-        pageObject.errorList.push({
-          text: 'Volunteering with children and young people is not marked as completed',
-          href: '#missing-school-experience'
-        })
-      }
-
-      if (typeof applicationData['work-history'] === 'undefined' || Object.keys(applicationData['work-history']).length === 0) {
-        pageObject.errorList.push({
-          text: 'Work history is not marked as completed',
-          href: '#missing-work-history'
-        })
-      }
-    }
-
-    res.render('application/review', pageObject)
-  })
-
-  router.post('/application/:applicationId/review', (req, res) => {
-    // If updating jobs or roles, ensure dates are saved using ISO 8601 format
-    const id = req.query.update
-    const applicationData = utils.applicationData(req)
-
-    // User tried to submit incomplete application
-    // just checking choices are empty for now
-    // to make real need to check over every section
-    if (typeof applicationData.choices === 'undefined' || Object.keys(applicationData.choices).length === 0 || Object.keys(applicationData['school-experience']).length === 0 || Object.keys(applicationData['work-history']).length === 0) {
-      req.flash('success', 'submitted-incompleted-application')
-      res.redirect(`/application/${req.params.applicationId}/review`)
-    } else {
-      const workHistory = applicationData['work-history']
-      const schoolExperience = applicationData['school-experience']
-      const referer = req.get('referer')
-
-      if (id && referer.includes('work-history')) {
-        utils.saveIsoDate(req, workHistory, id)
-      }
-
-      if (id && referer.includes('school-experience')) {
-        utils.saveIsoDate(req, schoolExperience, id)
-      }
-
-      res.render('application/review')
-    }
-  })
-
   // Render submitted page
   router.all('/application/:applicationId/submitted', (req, res) => {
     const { phase } = req.query
@@ -224,6 +180,7 @@ module.exports = router => {
   require('./application/subject-knowledge')(router)
   require('./application/interview')(router)
   require('./application/references')(router)
+  require('./application/review')(router)
   require('./application/equality-monitoring')(router)
   require('./application/confirmation')(router)
   require('./application/edit')(router)

--- a/app/routes/application/degree.js
+++ b/app/routes/application/degree.js
@@ -3,7 +3,11 @@ const utils = require('./../../utils')
 
 const degreeData = (req) => {
   const applicationData = utils.applicationData(req)
-  return applicationData.degree[req.params.id]
+  if (applicationData.degree[req.params.id]) {
+    return applicationData.degree[req.params.id]
+  }
+
+  return false
 }
 
 const degreePaths = (req) => {
@@ -42,11 +46,16 @@ module.exports = router => {
 
   // Render first page
   router.get('/application/:applicationId/degree/:id', (req, res) => {
+    const completedDegree = degreeData(req).grade && degreeData(req).year
+
     const id = req.params.id
     const referrer = req.query.referrer
+    const nextPath = `/application/${req.params.applicationId}/degree/${id}/answer?${utils.queryString(req)}`
+    // If completed this section, return to referrer, else next question
+    const formaction = completedDegree ? referrer : nextPath
 
     res.render('application/degree/index', {
-      formaction: referrer || `/application/${req.params.applicationId}/degree/${id}/answer?${utils.queryString(req)}`,
+      formaction,
       id,
       referrer
     })
@@ -71,13 +80,16 @@ module.exports = router => {
 
   // Render NARIC/grade/year pages
   router.all('/application/:applicationId/degree/:id/:template(naric|grade|year)', (req, res) => {
+    const completedDegree = degreeData(req).grade && degreeData(req).year
+
     const id = req.params.id
     const referrer = req.query.referrer
     const template = req.params.template
     const paths = degreePaths(req)
+    const formaction = completedDegree ? referrer : paths.next
 
     res.render(`application/degree/${template}`, {
-      formaction: referrer || paths.next,
+      formaction,
       paths,
       id,
       referrer

--- a/app/routes/application/personal-details.js
+++ b/app/routes/application/personal-details.js
@@ -6,7 +6,10 @@ const utils = require('./../../utils')
 module.exports = router => {
   // First page
   router.get('/application/:applicationId/personal-details', (req, res) => {
+    const referrer = req.query.referrer
+
     res.render('application/personal-details/index', {
+      referrer,
       formaction: `/application/${req.params.applicationId}/personal-details/answer?${utils.queryString(req)}`
     })
   })

--- a/app/routes/application/review.js
+++ b/app/routes/application/review.js
@@ -9,117 +9,46 @@ module.exports = router => {
     var pageObject = {}
     var successFlash = req.flash('success')
 
-    // Application sections
-    const { candidate, choices, degree, interview, referees } = applicationData
-    const { maths, english, science } = applicationData.gcse
-    const contactDetails = applicationData['contact-details']
-    const personalStatement = applicationData['personal-statement']
-    const reasonableAdjustments = applicationData['reasonable-adjustments']
-    const schoolExperience = applicationData['school-experience']
-    const subjectKnowledge = applicationData['subject-knowledge']
-    const workHistory = applicationData['work-history']
-
     if (successFlash[0] === 'submitted-incompleted-application') {
       pageObject.errorList = []
-
-      if (Object.keys(choices).length === 0) {
-        pageObject.errorList.push({
-          text: 'Course choices not marked as completed',
-          href: '#missing-course-choices'
-        })
+      const sections = {
+        choices: 'Course choices not marked as completed',
+        candidate: 'Personal details not entered',
+        'contact-details': 'Contact details not entered',
+        'reasonable-adjustments': 'Training with a disability not entered',
+        'work-history': 'Work history is not marked as completed',
+        'school-experience': 'Volunteering with children and young people is not marked as completed',
+        degree: 'Degree(s) are not marked as completed',
+        'personal-statement': 'Tell us why you want to be a teacher',
+        'subject-knowledge': 'Tell us about your knowledge about the subject you want to teach',
+        gcse: {
+          maths: 'Maths GCSE or equivalent not entered',
+          english: 'English GCSE or equivalent not entered',
+          science: 'Science GCSE or equivalent not entered'
+        },
+        interview: 'Tell us your interview preferences',
+        referees: 'Add 2 referees to your application'
       }
 
-      if (Object.keys(candidate).length === 0) {
-        pageObject.errorList.push({
-          text: 'Personal details not entered',
-          href: '#missing-personal-details'
-        })
-      }
-
-      if (Object.keys(contactDetails).length === 0) {
-        pageObject.errorList.push({
-          text: 'Contact details not entered',
-          href: '#missing-contact-details'
-        })
-      }
-
-      if (Object.keys(reasonableAdjustments).length === 0) {
-        pageObject.errorList.push({
-          text: 'Training with a disability not entered',
-          href: '#missing-reasonable-adjustments'
-        })
-      }
-
-      if (Object.keys(workHistory).length === 0) {
-        pageObject.errorList.push({
-          text: 'Work history is not marked as completed',
-          href: '#missing-work-history'
-        })
-      }
-
-      if (Object.keys(schoolExperience).length === 0) {
-        pageObject.errorList.push({
-          text: 'Volunteering with children and young people is not marked as completed',
-          href: '#missing-school-experience'
-        })
-      }
-
-      if (Object.keys(degree).length === 0) {
-        pageObject.errorList.push({
-          text: 'Degree(s) are not marked as completed',
-          href: '#missing-degree'
-        })
-      }
-
-      if (Object.keys(maths).length === 0) {
-        pageObject.errorList.push({
-          text: 'Maths GCSE or equivalent not entered',
-          href: '#missing-maths-gcse'
-        })
-      }
-
-      if (Object.keys(english).length === 0) {
-        pageObject.errorList.push({
-          text: 'English GCSE or equivalent not entered',
-          href: '#missing-english-gcse'
-        })
-      }
-
-      if (Object.keys(science).length === 0) {
-        pageObject.errorList.push({
-          text: 'Science GCSE or equivalent not entered',
-          href: '#missing-science-gcse'
-        })
-      }
-
-      console.log('personalStatement', personalStatement)
-
-      if (personalStatement === null) {
-        pageObject.errorList.push({
-          text: 'Tell us why you want to be a teacher',
-          href: '#missing-personal-statement'
-        })
-      }
-
-      if (subjectKnowledge === null) {
-        pageObject.errorList.push({
-          text: 'Tell us about your knowledge about the subject you want to teach',
-          href: '#missing-subject-knowledge'
-        })
-      }
-
-      if (interview === null) {
-        pageObject.errorList.push({
-          text: 'Tell us your interview preferences',
-          href: '#missing-interview'
-        })
-      }
-
-      if (Object.keys(referees).length === 0) {
-        pageObject.errorList.push({
-          text: 'Add 2 referees to your application',
-          href: '#missing-referees'
-        })
+      for (const [key, value] of Object.entries(sections)) {
+        if (key === 'gcse') {
+          const subjects = ['maths', 'english', 'science']
+          subjects.forEach(subject => {
+            if (Object.keys(applicationData.gcse[subject]).length === 0) {
+              pageObject.errorList.push({
+                text: value[subject],
+                href: `#missing-gcse-${subject}`
+              })
+            }
+          })
+        } else {
+          if (applicationData[key] === null || Object.keys(applicationData[key]).length === 0) {
+            pageObject.errorList.push({
+              text: value,
+              href: `#missing-${key}`
+            })
+          }
+        }
       }
     }
 

--- a/app/routes/application/review.js
+++ b/app/routes/application/review.js
@@ -107,7 +107,6 @@ module.exports = router => {
       req.flash('success', 'submitted-incompleted-application')
       res.redirect(`/application/${req.params.applicationId}/review`)
     } else {
-      console.log('applicationData.status', applicationData.status)
       if (status === 'amending') {
         res.redirect(`/application/${req.params.applicationId}/submit`)
       } else {

--- a/app/routes/application/review.js
+++ b/app/routes/application/review.js
@@ -10,10 +10,14 @@ module.exports = router => {
     var successFlash = req.flash('success')
 
     // Application sections
-    const { choices } = applicationData
-    const workHistory = applicationData['work-history']
+    const { candidate, choices, degree, interview, referees } = applicationData
+    const { maths, english, science } = applicationData.gcse
+    const contactDetails = applicationData['contact-details']
+    const personalStatement = applicationData['personal-statement']
+    const reasonableAdjustments = applicationData['reasonable-adjustments']
     const schoolExperience = applicationData['school-experience']
-    const scienceGcse = applicationData.gcse.science
+    const subjectKnowledge = applicationData['subject-knowledge']
+    const workHistory = applicationData['work-history']
 
     if (successFlash[0] === 'submitted-incompleted-application') {
       pageObject.errorList = []
@@ -25,17 +29,24 @@ module.exports = router => {
         })
       }
 
-      if (Object.keys(schoolExperience).length === 0) {
+      if (Object.keys(candidate).length === 0) {
         pageObject.errorList.push({
-          text: 'Volunteering with children and young people is not marked as completed',
-          href: '#missing-school-experience'
+          text: 'Personal details not entered',
+          href: '#missing-personal-details'
         })
       }
 
-      if (Object.keys(scienceGcse).length === 0) {
+      if (Object.keys(contactDetails).length === 0) {
         pageObject.errorList.push({
-          text: 'Science GCSE or equivalent not entered',
-          href: '#missing-science-gcse'
+          text: 'Contact details not entered',
+          href: '#missing-contact-details'
+        })
+      }
+
+      if (Object.keys(reasonableAdjustments).length === 0) {
+        pageObject.errorList.push({
+          text: 'Training with a disability not entered',
+          href: '#missing-reasonable-adjustments'
         })
       }
 
@@ -45,20 +56,104 @@ module.exports = router => {
           href: '#missing-work-history'
         })
       }
+
+      if (Object.keys(schoolExperience).length === 0) {
+        pageObject.errorList.push({
+          text: 'Volunteering with children and young people is not marked as completed',
+          href: '#missing-school-experience'
+        })
+      }
+
+      if (Object.keys(degree).length === 0) {
+        pageObject.errorList.push({
+          text: 'Degree(s) are not marked as completed',
+          href: '#missing-degree'
+        })
+      }
+
+      if (Object.keys(maths).length === 0) {
+        pageObject.errorList.push({
+          text: 'Maths GCSE or equivalent not entered',
+          href: '#missing-maths-gcse'
+        })
+      }
+
+      if (Object.keys(english).length === 0) {
+        pageObject.errorList.push({
+          text: 'English GCSE or equivalent not entered',
+          href: '#missing-english-gcse'
+        })
+      }
+
+      if (Object.keys(science).length === 0) {
+        pageObject.errorList.push({
+          text: 'Science GCSE or equivalent not entered',
+          href: '#missing-science-gcse'
+        })
+      }
+
+      console.log('personalStatement', personalStatement)
+
+      if (personalStatement === null) {
+        pageObject.errorList.push({
+          text: 'Tell us why you want to be a teacher',
+          href: '#missing-personal-statement'
+        })
+      }
+
+      if (subjectKnowledge === null) {
+        pageObject.errorList.push({
+          text: 'Tell us about your knowledge about the subject you want to teach',
+          href: '#missing-subject-knowledge'
+        })
+      }
+
+      if (interview === null) {
+        pageObject.errorList.push({
+          text: 'Tell us your interview preferences',
+          href: '#missing-interview'
+        })
+      }
+
+      if (Object.keys(referees).length === 0) {
+        pageObject.errorList.push({
+          text: 'Add 2 referees to your application',
+          href: '#missing-referees'
+        })
+      }
     }
 
     res.render('application/review', pageObject)
   })
 
   router.post('/application/:applicationId/review', (req, res) => {
-    // If updating jobs or roles, ensure dates are saved using ISO 8601 format
+    // If updating job/role, ensure dates are saved using ISO 8601
     const id = req.query.update
+    const applicationData = utils.applicationData(req)
+    const referer = req.get('referer')
+
+    if (id && referer.includes('work-history')) {
+      utils.saveIsoDate(req, applicationData['work-history'], id)
+    }
+
+    if (id && referer.includes('school-experience')) {
+      utils.saveIsoDate(req, applicationData['school-experience'], id)
+    }
+
+    res.render('application/review')
+  })
+
+  router.post('/application/:applicationId/review-complete', (req, res) => {
     const applicationData = utils.applicationData(req)
 
     // Application sections
-    const { choices } = applicationData
+    const { candidate, choices, degree, interview, status, referees } = applicationData
+    const { maths, english, science } = applicationData.gcse
+    const contactDetails = applicationData['contact-details']
+    const personalStatement = applicationData['personal-statement']
+    const reasonableAdjustments = applicationData['reasonable-adjustments']
     const schoolExperience = applicationData['school-experience']
-    const scienceGcse = applicationData.gcse.science
+    const subjectKnowledge = applicationData['subject-knowledge']
     const workHistory = applicationData['work-history']
 
     // User tried to submit incomplete application
@@ -66,24 +161,29 @@ module.exports = router => {
     // to make real need to check over every section
     if (
       Object.keys(choices).length === 0 ||
+      Object.keys(candidate).length === 0 ||
+      Object.keys(contactDetails).length === 0 ||
+      Object.keys(reasonableAdjustments).length === 0 ||
+      Object.keys(workHistory).length === 0 ||
       Object.keys(schoolExperience).length === 0 ||
-      Object.keys(scienceGcse).length === 0 ||
-      Object.keys(workHistory).length === 0
+      Object.keys(degree).length === 0 ||
+      Object.keys(maths).length === 0 ||
+      Object.keys(english).length === 0 ||
+      Object.keys(science).length === 0 ||
+      Object.keys(personalStatement).length === 0 ||
+      Object.keys(subjectKnowledge).length === 0 ||
+      Object.keys(interview).length === 0 ||
+      Object.keys(referees).length === 0
     ) {
       req.flash('success', 'submitted-incompleted-application')
       res.redirect(`/application/${req.params.applicationId}/review`)
     } else {
-      const referer = req.get('referer')
-
-      if (id && referer.includes('work-history')) {
-        utils.saveIsoDate(req, workHistory, id)
+      console.log('applicationData.status', applicationData.status)
+      if (status === 'amending') {
+        res.redirect(`/application/${req.params.applicationId}/submit`)
+      } else {
+        res.redirect(`/application/${req.params.applicationId}/equality-monitoring`)
       }
-
-      if (id && referer.includes('school-experience')) {
-        utils.saveIsoDate(req, schoolExperience, id)
-      }
-
-      res.render('application/review')
     }
   })
 }

--- a/app/routes/application/review.js
+++ b/app/routes/application/review.js
@@ -1,0 +1,89 @@
+const utils = require('./../../utils')
+
+/**
+ * Application: Review answers
+ */
+module.exports = router => {
+  router.get('/application/:applicationId/review', (req, res) => {
+    var applicationData = utils.applicationData(req)
+    var pageObject = {}
+    var successFlash = req.flash('success')
+
+    // Application sections
+    const { choices } = applicationData
+    const workHistory = applicationData['work-history']
+    const schoolExperience = applicationData['school-experience']
+    const scienceGcse = applicationData.gcse.science
+
+    if (successFlash[0] === 'submitted-incompleted-application') {
+      pageObject.errorList = []
+
+      if (Object.keys(choices).length === 0) {
+        pageObject.errorList.push({
+          text: 'Course choices not marked as completed',
+          href: '#missing-course-choices'
+        })
+      }
+
+      if (Object.keys(schoolExperience).length === 0) {
+        pageObject.errorList.push({
+          text: 'Volunteering with children and young people is not marked as completed',
+          href: '#missing-school-experience'
+        })
+      }
+
+      if (Object.keys(scienceGcse).length === 0) {
+        pageObject.errorList.push({
+          text: 'Science GCSE or equivalent not entered',
+          href: '#missing-science-gcse'
+        })
+      }
+
+      if (Object.keys(workHistory).length === 0) {
+        pageObject.errorList.push({
+          text: 'Work history is not marked as completed',
+          href: '#missing-work-history'
+        })
+      }
+    }
+
+    res.render('application/review', pageObject)
+  })
+
+  router.post('/application/:applicationId/review', (req, res) => {
+    // If updating jobs or roles, ensure dates are saved using ISO 8601 format
+    const id = req.query.update
+    const applicationData = utils.applicationData(req)
+
+    // Application sections
+    const { choices } = applicationData
+    const schoolExperience = applicationData['school-experience']
+    const scienceGcse = applicationData.gcse.science
+    const workHistory = applicationData['work-history']
+
+    // User tried to submit incomplete application
+    // just checking choices are empty for now
+    // to make real need to check over every section
+    if (
+      Object.keys(choices).length === 0 ||
+      Object.keys(schoolExperience).length === 0 ||
+      Object.keys(scienceGcse).length === 0 ||
+      Object.keys(workHistory).length === 0
+    ) {
+      req.flash('success', 'submitted-incompleted-application')
+      res.redirect(`/application/${req.params.applicationId}/review`)
+    } else {
+      const referer = req.get('referer')
+
+      if (id && referer.includes('work-history')) {
+        utils.saveIsoDate(req, workHistory, id)
+      }
+
+      if (id && referer.includes('school-experience')) {
+        utils.saveIsoDate(req, schoolExperience, id)
+      }
+
+      res.render('application/review')
+    }
+  })
+}

--- a/app/routes/application/review.js
+++ b/app/routes/application/review.js
@@ -34,7 +34,7 @@ module.exports = router => {
         if (key === 'gcse') {
           const subjects = ['maths', 'english', 'science']
           subjects.forEach(subject => {
-            if (Object.keys(applicationData.gcse[subject]).length === 0) {
+            if (!utils.hasCompletedSection(applicationData.gcse[subject])) {
               pageObject.errorList.push({
                 text: value[subject],
                 href: `#missing-gcse-${subject}`
@@ -42,7 +42,7 @@ module.exports = router => {
             }
           })
         } else {
-          if (applicationData[key] === null || Object.keys(applicationData[key]).length === 0) {
+          if (!utils.hasCompletedSection(applicationData[key])) {
             pageObject.errorList.push({
               text: value,
               href: `#missing-${key}`
@@ -74,44 +74,18 @@ module.exports = router => {
 
   router.post('/application/:applicationId/review-complete', (req, res) => {
     const applicationData = utils.applicationData(req)
+    const completedApplication = utils.hasCompletedApplication(req)
 
-    // Application sections
-    const { candidate, choices, degree, interview, status, referees } = applicationData
-    const { maths, english, science } = applicationData.gcse
-    const contactDetails = applicationData['contact-details']
-    const personalStatement = applicationData['personal-statement']
-    const reasonableAdjustments = applicationData['reasonable-adjustments']
-    const schoolExperience = applicationData['school-experience']
-    const subjectKnowledge = applicationData['subject-knowledge']
-    const workHistory = applicationData['work-history']
-
-    // User tried to submit incomplete application
-    // just checking choices are empty for now
-    // to make real need to check over every section
-    if (
-      Object.keys(choices).length === 0 ||
-      Object.keys(candidate).length === 0 ||
-      Object.keys(contactDetails).length === 0 ||
-      Object.keys(reasonableAdjustments).length === 0 ||
-      Object.keys(workHistory).length === 0 ||
-      Object.keys(schoolExperience).length === 0 ||
-      Object.keys(degree).length === 0 ||
-      Object.keys(maths).length === 0 ||
-      Object.keys(english).length === 0 ||
-      Object.keys(science).length === 0 ||
-      Object.keys(personalStatement).length === 0 ||
-      Object.keys(subjectKnowledge).length === 0 ||
-      Object.keys(interview).length === 0 ||
-      Object.keys(referees).length === 0
-    ) {
-      req.flash('success', 'submitted-incompleted-application')
-      res.redirect(`/application/${req.params.applicationId}/review`)
-    } else {
+    if (completedApplication) {
+      const { status } = applicationData
       if (status === 'amending') {
         res.redirect(`/application/${req.params.applicationId}/submit`)
       } else {
         res.redirect(`/application/${req.params.applicationId}/equality-monitoring`)
       }
+    } else {
+      req.flash('success', 'submitted-incompleted-application')
+      res.redirect(`/application/${req.params.applicationId}/review`)
     }
   })
 }

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -65,6 +65,39 @@ const hasStartedApplications = (req) => {
   }
 }
 
+const hasCompletedSection = key => {
+  if (!key || key === null || Object.keys(key).length === 0) {
+    return false
+  }
+
+  return true
+}
+
+const hasCompletedApplication = req => {
+  var application = req.session.data.applications[req.params.applicationId]
+  if (
+    module.exports.hasCompletedSection(application.choices) &&
+    module.exports.hasCompletedSection(application.candidate) &&
+    module.exports.hasCompletedSection(application['contact-details']) &&
+    module.exports.hasCompletedSection(application['reasonable-adjustments']) &&
+    module.exports.hasCompletedSection(application['work-history']) &&
+    module.exports.hasCompletedSection(application['school-experience']) &&
+    module.exports.hasCompletedSection(application.degree) &&
+    module.exports.hasCompletedSection(application.gcse.maths) &&
+    module.exports.hasCompletedSection(application.gcse.english) &&
+    module.exports.hasCompletedSection(application.gcse.science) &&
+    module.exports.hasCompletedSection(application['personal-statement']) &&
+    module.exports.hasCompletedSection(application['subject-knowledge']) &&
+    module.exports.hasCompletedSection(application.interview) &&
+    module.exports.hasCompletedSection(application.referees)
+  ) {
+    console.log('has completed application')
+    return true
+  }
+
+  return false
+}
+
 const hasPrimaryChoices = (req) => {
   try {
     var choices = req.session.data.applications[req.params.applicationId].choices
@@ -100,6 +133,8 @@ module.exports = {
   queryString: getQueryString,
   saveIsoDate,
   hasApplications,
+  hasCompletedApplication,
+  hasCompletedSection,
   hasPrimaryChoices,
   hasSubmittedApplications,
   hasStartedApplications,

--- a/app/views/_components/banner/template.njk
+++ b/app/views/_components/banner/template.njk
@@ -1,14 +1,4 @@
 <div class="app-banner{% if params.type == "success" %} app-banner--success{% elif params.type == "warning" %} app-banner--warning{% endif %}{{- " " + params.classes if params.classes}}" {%- for attribute, value in params.attributes -%} {{ attribute }}="{{ value }}"{% endfor %}>
-{% if params.icon != false %}
-  {% if params.type == "success" %}
-    <svg class="app-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25"><path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z"/></svg>
-  {% elif params.type == "warning" %}
-    <svg class="app-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25"><path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z"/></svg>
-  {% elif params.type == "information" %}
-    <svg class="app-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25"><path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
-	C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z"/></svg>
-  {% endif %}
-{% endif %}
   <div class="app-banner__message">
     {% if params.iconFallbackText %}<span class="app-banner__assistive">{{ params.iconFallbackText }}</span>{% endif %}
     {{- params.html | safe if params.html else params.text -}}

--- a/app/views/_components/banner/template.njk
+++ b/app/views/_components/banner/template.njk
@@ -1,4 +1,14 @@
 <div class="app-banner{% if params.type == "success" %} app-banner--success{% elif params.type == "warning" %} app-banner--warning{% endif %}{{- " " + params.classes if params.classes}}" {%- for attribute, value in params.attributes -%} {{ attribute }}="{{ value }}"{% endfor %}>
+{% if params.icon != false %}
+  {% if params.type == "success" %}
+    <svg class="app-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25"><path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z"/></svg>
+  {% elif params.type == "warning" %}
+    <svg class="app-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25"><path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z"/></svg>
+  {% elif params.type == "information" %}
+    <svg class="app-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25"><path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
+	C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z"/></svg>
+  {% endif %}
+{% endif %}
   <div class="app-banner__message">
     {% if params.iconFallbackText %}<span class="app-banner__assistive">{{ params.iconFallbackText }}</span>{% endif %}
     {{- params.html | safe if params.html else params.text -}}

--- a/app/views/_includes/review/choices.njk
+++ b/app/views/_includes/review/choices.njk
@@ -49,6 +49,7 @@
     }) }}
   {% endfor %}
 {% else %}
+  {% set incompleteType = "warning" if errorList %}
   {% set incompleteId = "course-choices" %}
   {% set incompleteText = "Course choices are not marked as completed" %}
   {% set incompleteLink = "/choices?referrer=" + referrer %}

--- a/app/views/_includes/review/choices.njk
+++ b/app/views/_includes/review/choices.njk
@@ -1,4 +1,5 @@
-{% if choices.length %}
+{% set complete = choices | length > 0 %}
+{% if complete %}
   {% for item in choices %}
     {% set provider = providers[item.providerCode] %}
     {% set course = provider.courses[item.courseCode] %}
@@ -49,9 +50,11 @@
     }) }}
   {% endfor %}
 {% else %}
-  {% set incompleteType = "warning" if errorList %}
-  {% set incompleteId = "course-choices" %}
-  {% set incompleteText = "Course choices are not marked as completed" %}
-  {% set incompleteLink = "/choices?referrer=" + referrer %}
-  {% include "_includes/review/incomplete.njk" %}
+  {% if showIncomplete %}
+    {% set incompleteType = "warning" if errorList %}
+    {% set incompleteId = "course-choices" %}
+    {% set incompleteText = "Course choices are not marked as completed" %}
+    {% set incompleteLink = "/choices?referrer=" + referrer %}
+    {% include "_includes/review/incomplete.njk" %}
+  {% endif %}
 {% endif %}

--- a/app/views/_includes/review/choices.njk
+++ b/app/views/_includes/review/choices.njk
@@ -52,7 +52,7 @@
 {% else %}
   {% if showIncomplete %}
     {% set incompleteType = "warning" if errorList %}
-    {% set incompleteId = "course-choices" %}
+    {% set incompleteId = "choices" %}
     {% set incompleteText = "Course choices are not marked as completed" %}
     {% set incompleteLink = "/choices?referrer=" + referrer %}
     {% include "_includes/review/incomplete.njk" %}

--- a/app/views/_includes/review/choices.njk
+++ b/app/views/_includes/review/choices.njk
@@ -1,49 +1,56 @@
-{% for item in choices %}
-  {% set provider = providers[item.providerCode] %}
-  {% set course = provider.courses[item.courseCode] %}
-  {% set courseHtml %}
-    {% include "_includes/item/choice.njk" %}
-  {% endset %}
+{% if choices.length %}
+  {% for item in choices %}
+    {% set provider = providers[item.providerCode] %}
+    {% set course = provider.courses[item.courseCode] %}
+    {% set courseHtml %}
+      {% include "_includes/item/choice.njk" %}
+    {% endset %}
 
-  {# Can respond if within a decision phase and have an offer #}
-  {% set canRespond = canMakeDecision and
-    item.status == "offer"
-  %}
+    {# Can respond if within a decision phase and have an offer #}
+    {% set canRespond = canMakeDecision and
+      item.status == "offer"
+    %}
 
-  {# Can withdraw if post-submission and not already withdrawn choice #}
-  {% set canWithdraw = canWithdraw
-    and (item.status != "declined")
-    and (item.status != "offer")
-    and (item.status != "rejected")
-    and (item.status != "withdrawn")
-    or (item.status == "pending")
-    or (item.status == "accepted")
-  %}
+    {# Can withdraw if post-submission and not already withdrawn choice #}
+    {% set canWithdraw = canWithdraw
+      and (item.status != "declined")
+      and (item.status != "offer")
+      and (item.status != "rejected")
+      and (item.status != "withdrawn")
+      or (item.status == "pending")
+      or (item.status == "accepted")
+    %}
 
-  {# Candidate has already responded #}
-  {% set hasResponded =
-    (item.status == "accepted")
-    or (item.status == "declined")
-    or (item.status == "rejected")
-    or (item.status == "withdrawn")
-  %}
+    {# Candidate has already responded #}
+    {% set hasResponded =
+      (item.status == "accepted")
+      or (item.status == "declined")
+      or (item.status == "rejected")
+      or (item.status == "withdrawn")
+    %}
 
-  {{ appSummaryCard({
-    classes: "govuk-!-margin-bottom-6",
-    headingLevel: 3,
-    titleText: provider.name,
-    actions: {
-      items: [{
-        href: applicationPath + "/choices/" + item.id + "/delete?referrer=" + referrer,
-        text: "Delete choice"
-      } if canAmend, {
-        href: applicationPath + "/" + item.id + "/withdraw",
-        text: "Withdraw"
-      } if canWithdraw, {
-        href: applicationPath + "/" + item.id + "/view?phase=" + phase,
-        text: "View and respond to offer"
-      } if canRespond and not hasResponded]
-    } if canAmend or canWithdraw or canRespond,
-    html: courseHtml
-  }) }}
-{% endfor %}
+    {{ appSummaryCard({
+      classes: "govuk-!-margin-bottom-6",
+      headingLevel: 3,
+      titleText: provider.name,
+      actions: {
+        items: [{
+          href: applicationPath + "/choices/" + item.id + "/delete?referrer=" + referrer,
+          text: "Delete choice"
+        } if canAmend, {
+          href: applicationPath + "/" + item.id + "/withdraw",
+          text: "Withdraw"
+        } if canWithdraw, {
+          href: applicationPath + "/" + item.id + "/view?phase=" + phase,
+          text: "View and respond to offer"
+        } if canRespond and not hasResponded]
+      } if canAmend or canWithdraw or canRespond,
+      html: courseHtml
+    }) }}
+  {% endfor %}
+{% else %}
+  {% set incompleteId = "course-choices" %}
+  {% set incompleteText = "Course choices are not marked as completed" %}
+  {% set incompleteLink = "/choices?referrer=" + referrer %}
+  {% include "_includes/review/incomplete.njk" %}
+{% endif %}

--- a/app/views/_includes/review/contact-details.njk
+++ b/app/views/_includes/review/contact-details.njk
@@ -76,7 +76,8 @@
   }) }}
 {% endset %}
 
-{% if contactDetails %}
+{% set complete = contactDetails | length > 0 %}
+{% if complete %}
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     html: contactDetailsHtml

--- a/app/views/_includes/review/contact-details.njk
+++ b/app/views/_includes/review/contact-details.njk
@@ -82,5 +82,8 @@
     html: contactDetailsHtml
   }) }}
 {% else %}
-  <p class="govuk-body">No contact details entered.</p>
+  {% set incompleteId = "contact-details" %}
+  {% set incompleteText = "Contact details not entered" %}
+  {% set incompleteLink = "/contact-details?referrer=" + referrer %}
+  {% include "_includes/review/incomplete.njk" %}
 {% endif %}

--- a/app/views/_includes/review/contact-details.njk
+++ b/app/views/_includes/review/contact-details.njk
@@ -82,6 +82,7 @@
     html: contactDetailsHtml
   }) }}
 {% else %}
+  {% set incompleteType = "warning" if errorList %}
   {% set incompleteId = "contact-details" %}
   {% set incompleteText = "Contact details not entered" %}
   {% set incompleteLink = "/contact-details?referrer=" + referrer %}

--- a/app/views/_includes/review/degrees.njk
+++ b/app/views/_includes/review/degrees.njk
@@ -1,7 +1,8 @@
 {% set applicationPath = "/application/" + applicationId %}
 {% set degrees = applicationValue(["degree"]) %}
 
-{% if degrees %}
+{% set complete = degrees | length > 0 %}
+{% if complete %}
   {% set degrees = degrees | toArray | selectattr("id") %}
   {% for item in degrees %}
     {% set degreeHtml %}

--- a/app/views/_includes/review/degrees.njk
+++ b/app/views/_includes/review/degrees.njk
@@ -21,6 +21,7 @@
     }) }}
   {% endfor %}
 {% else %}
+  {% set incompleteType = "warning" if errorList %}
   {% set incompleteId = "degrees" %}
   {% set incompleteText = "Degree(s) are not marked as completed" %}
   {% set incompleteLink = "/degree/add?referrer=" + referrer %}

--- a/app/views/_includes/review/degrees.njk
+++ b/app/views/_includes/review/degrees.njk
@@ -21,5 +21,8 @@
     }) }}
   {% endfor %}
 {% else %}
-  <p class="govuk-body">No degrees entered.</p>
+  {% set incompleteId = "degrees" %}
+  {% set incompleteText = "Degree(s) are not marked as completed" %}
+  {% set incompleteLink = "/degree/add?referrer=" + referrer %}
+  {% include "_includes/review/incomplete.njk" %}
 {% endif %}

--- a/app/views/_includes/review/degrees.njk
+++ b/app/views/_includes/review/degrees.njk
@@ -23,7 +23,7 @@
   {% endfor %}
 {% else %}
   {% set incompleteType = "warning" if errorList %}
-  {% set incompleteId = "degrees" %}
+  {% set incompleteId = "degree" %}
   {% set incompleteText = "Degree(s) are not marked as completed" %}
   {% set incompleteLink = "/degree/add?referrer=" + referrer %}
   {% include "_includes/review/incomplete.njk" %}

--- a/app/views/_includes/review/gcse.njk
+++ b/app/views/_includes/review/gcse.njk
@@ -10,5 +10,8 @@
     html: gcseHtml
   }) }}
 {% else %}
-  <p class="govuk-body">Incomplete</p>
+  {% set incompleteId = id + "-gcse" %}
+  {% set incompleteText = id | capitalize + " GCSE or equivalent not entered" %}
+  {% set incompleteLink = "/gcse/" + id + "?referrer=" + referrer %}
+  {% include "_includes/review/incomplete.njk" %}
 {% endif %}

--- a/app/views/_includes/review/gcse.njk
+++ b/app/views/_includes/review/gcse.njk
@@ -1,5 +1,7 @@
 {% set item = applicationValue(["gcse", id]) %}
-{% if item %}
+
+{% set complete = item | length > 0 %}
+{% if complete %}
   {% set gcseHtml %}
     {% include "_includes/item/gcse.njk" %}
   {% endset %}

--- a/app/views/_includes/review/gcse.njk
+++ b/app/views/_includes/review/gcse.njk
@@ -10,6 +10,7 @@
     html: gcseHtml
   }) }}
 {% else %}
+  {% set incompleteType = "warning" if errorList %}
   {% set incompleteId = id + "-gcse" %}
   {% set incompleteText = id | capitalize + " GCSE or equivalent not entered" %}
   {% set incompleteLink = "/gcse/" + id + "?referrer=" + referrer %}

--- a/app/views/_includes/review/gcse.njk
+++ b/app/views/_includes/review/gcse.njk
@@ -13,7 +13,7 @@
   }) }}
 {% else %}
   {% set incompleteType = "warning" if errorList %}
-  {% set incompleteId = id + "-gcse" %}
+  {% set incompleteId = "gcse-" + id %}
   {% set incompleteText = id | capitalize + " GCSE or equivalent not entered" %}
   {% set incompleteLink = "/gcse/" + id + "?referrer=" + referrer %}
   {% include "_includes/review/incomplete.njk" %}

--- a/app/views/_includes/review/incomplete.njk
+++ b/app/views/_includes/review/incomplete.njk
@@ -1,0 +1,9 @@
+{% set bannerHtml %}
+  <p class="govuk-body" id="missing-{{ incompleteId }}">{{ incompleteText }}</p>
+  <a class="govuk-link" aria-describedby="missing-{{ incompleteId }}" href="{{ applicationPath }}{{ incompleteLink }}">Complete section</a>
+{% endset %}
+
+{{ appBanner({
+  classes: "app-banner--missing-section",
+  html: bannerHtml
+}) }}

--- a/app/views/_includes/review/incomplete.njk
+++ b/app/views/_includes/review/incomplete.njk
@@ -6,5 +6,6 @@
 {{ appBanner({
   classes: "app-banner--missing-section",
   html: bannerHtml,
-  type: incompleteType
+  type: incompleteType or "information",
+  icon: false
 }) }}

--- a/app/views/_includes/review/incomplete.njk
+++ b/app/views/_includes/review/incomplete.njk
@@ -5,5 +5,6 @@
 
 {{ appBanner({
   classes: "app-banner--missing-section",
-  html: bannerHtml
+  html: bannerHtml,
+  type: incompleteType
 }) }}

--- a/app/views/_includes/review/interview.njk
+++ b/app/views/_includes/review/interview.njk
@@ -26,6 +26,7 @@
     html: interviewHtml
   }) }}
 {% else %}
+  {% set incompleteType = "warning" if errorList %}
   {% set incompleteId = "interview" %}
   {% set incompleteText = "Tell us your interview preferences" %}
   {% set incompleteLink = "/interview?referrer=" + referrer %}

--- a/app/views/_includes/review/interview.njk
+++ b/app/views/_includes/review/interview.njk
@@ -26,28 +26,8 @@
     html: interviewHtml
   }) }}
 {% else %}
-
-  {% set interviewHtml %}
-    {# {{ govukErrorMessage({
-      text: "Interview preferences incomplete",
-      visuallyHiddenText: ""
-    }) }} #}
-
-    <p class="govuk-body">Interview preferences incomplete</p>
-
-    {{govukButton({
-      text: 'Go to section',
-      classes: 'govuk-button--secondary govuk-!-margin-bottom-0'
-    })}}
-
-  {% endset %}
-
-  {{ appSummaryCard({
-    atttributes: {
-      id: 'interview-preferences-error'
-    },
-    classes: "govuk-!-margin-bottom-6 app-summary-card--erro",
-    html: interviewHtml
-  }) }}
-
+  {% set incompleteId = "interview" %}
+  {% set incompleteText = "Tell us your interview preferences" %}
+  {% set incompleteLink = "/interview?referrer=" + referrer %}
+  {% include "_includes/review/incomplete.njk" %}
 {% endif %}

--- a/app/views/_includes/review/interview.njk
+++ b/app/views/_includes/review/interview.njk
@@ -20,7 +20,8 @@
   }) }}
 {% endset %}
 
-{% if applicationValue(["interview"]) %}
+{% set complete = applicationValue(["interview"]) | length > 0 %}
+{% if complete %}
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     html: interviewHtml

--- a/app/views/_includes/review/personal-details.njk
+++ b/app/views/_includes/review/personal-details.njk
@@ -153,7 +153,7 @@
   }) }}
 {% else %}
   {% set incompleteType = "warning" if errorList %}
-  {% set incompleteId = "personal-details" %}
+  {% set incompleteId = "candidate" %}
   {% set incompleteText = "Personal details not entered" %}
   {% set incompleteLink = "/personal-details?referrer=" + referrer %}
   {% include "_includes/review/incomplete.njk" %}

--- a/app/views/_includes/review/personal-details.njk
+++ b/app/views/_includes/review/personal-details.njk
@@ -151,6 +151,7 @@
     html: personalDetailsHtml
   }) }}
 {% else %}
+  {% set incompleteType = "warning" if errorList %}
   {% set incompleteId = "personal-details" %}
   {% set incompleteText = "Personal details not entered" %}
   {% set incompleteLink = "/personal-details?referrer=" + referrer %}

--- a/app/views/_includes/review/personal-details.njk
+++ b/app/views/_includes/review/personal-details.njk
@@ -145,7 +145,8 @@
   }) }}
 {% endset %}
 
-{% if applicationValue("candidate") %}
+{% set complete = applicationValue(["candidate"]) | length > 0 %}
+{% if complete %}
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     html: personalDetailsHtml

--- a/app/views/_includes/review/personal-details.njk
+++ b/app/views/_includes/review/personal-details.njk
@@ -151,5 +151,8 @@
     html: personalDetailsHtml
   }) }}
 {% else %}
-  <p class="govuk-body">No personal details entered.</p>
+  {% set incompleteId = "personal-details" %}
+  {% set incompleteText = "Personal details not entered" %}
+  {% set incompleteLink = "/personal-details?referrer=" + referrer %}
+  {% include "_includes/review/incomplete.njk" %}
 {% endif %}

--- a/app/views/_includes/review/personal-statement.njk
+++ b/app/views/_includes/review/personal-statement.njk
@@ -19,7 +19,8 @@
   }) }}
 {% endset %}
 
-{% if applicationValue(["personal-statement"]) %}
+{% set complete = applicationValue(["personal-statement"]) | length > 0 %}
+{% if complete %}
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     html: personalStatementHtml

--- a/app/views/_includes/review/personal-statement.njk
+++ b/app/views/_includes/review/personal-statement.njk
@@ -25,5 +25,8 @@
     html: personalStatementHtml
   }) }}
 {% else %}
-  <p class="govuk-body">Personal statement not complete</p>
+  {% set incompleteId = "personal-statement" %}
+  {% set incompleteText = "Tell us why you want to be a teacher" %}
+  {% set incompleteLink = "/personal-statement?referrer=" + referrer %}
+  {% include "_includes/review/incomplete.njk" %}
 {% endif %}

--- a/app/views/_includes/review/personal-statement.njk
+++ b/app/views/_includes/review/personal-statement.njk
@@ -25,6 +25,7 @@
     html: personalStatementHtml
   }) }}
 {% else %}
+  {% set incompleteType = "warning" if errorList %}
   {% set incompleteId = "personal-statement" %}
   {% set incompleteText = "Tell us why you want to be a teacher" %}
   {% set incompleteLink = "/personal-statement?referrer=" + referrer %}

--- a/app/views/_includes/review/reasonable-adjustments.njk
+++ b/app/views/_includes/review/reasonable-adjustments.njk
@@ -33,7 +33,8 @@
   }) }}
 {% endset %}
 
-{% if applicationValue("reasonable-adjustments") %}
+{% set complete = applicationValue(["reasonable-adjustments"]) | length > 0 %}
+{% if complete %}
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     html: supportDetailsHtml

--- a/app/views/_includes/review/reasonable-adjustments.njk
+++ b/app/views/_includes/review/reasonable-adjustments.njk
@@ -39,5 +39,8 @@
     html: supportDetailsHtml
   }) }}
 {% else %}
-  <p class="govuk-body">No choice made about needing support to become a teacher.</p>
+  {% set incompleteId = "reasonable-adjustments" %}
+  {% set incompleteText = "Training with a disability not entered" %}
+  {% set incompleteLink = "/reasonable-adjustments?referrer=" + referrer %}
+  {% include "_includes/review/incomplete.njk" %}
 {% endif %}

--- a/app/views/_includes/review/reasonable-adjustments.njk
+++ b/app/views/_includes/review/reasonable-adjustments.njk
@@ -39,6 +39,7 @@
     html: supportDetailsHtml
   }) }}
 {% else %}
+  {% set incompleteType = "warning" if errorList %}
   {% set incompleteId = "reasonable-adjustments" %}
   {% set incompleteText = "Training with a disability not entered" %}
   {% set incompleteLink = "/reasonable-adjustments?referrer=" + referrer %}

--- a/app/views/_includes/review/references.njk
+++ b/app/views/_includes/review/references.njk
@@ -27,7 +27,7 @@
   {% endfor %}
 {% else %}
   {% set incompleteType = "warning" if errorList %}
-  {% set incompleteId = "references" %}
+  {% set incompleteId = "referees" %}
   {% set incompleteText = "Add 2 referees to your application" %}
   {% set incompleteLink = "/references/?referrer=" + referrer %}
   {% include "_includes/review/incomplete.njk" %}

--- a/app/views/_includes/review/references.njk
+++ b/app/views/_includes/review/references.njk
@@ -1,4 +1,5 @@
-{% if references %}
+{% set complete = references | length > 0 %}
+{% if complete %}
   {% set canAmend = true if not hasSubmittedApplications() %}
   {% if not canAmend %}
     <p class="govuk-body">We’ve contacted the referees you provided below. We’ll let you know if they don’t supply a reference.</p>

--- a/app/views/_includes/review/references.njk
+++ b/app/views/_includes/review/references.njk
@@ -25,6 +25,7 @@
     }) }}
   {% endfor %}
 {% else %}
+  {% set incompleteType = "warning" if errorList %}
   {% set incompleteId = "references" %}
   {% set incompleteText = "Add 2 referees to your application" %}
   {% set incompleteLink = "/references/?referrer=" + referrer %}

--- a/app/views/_includes/review/references.njk
+++ b/app/views/_includes/review/references.njk
@@ -3,6 +3,7 @@
   {% if not canAmend %}
     <p class="govuk-body">We’ve contacted the referees you provided below. We’ll let you know if they don’t supply a reference.</p>
   {% else %}
+    {# You can’t change your referees once application has been submitted #}
     <p class="govuk-body">We’ll contact your referees after you submit your application. We’ll let you know if they don’t supply a reference.</p>
   {% endif %}
   {% set references = references | toArray %}
@@ -24,5 +25,8 @@
     }) }}
   {% endfor %}
 {% else %}
-  <p class="govuk-body">No references entered.</p>
+  {% set incompleteId = "references" %}
+  {% set incompleteText = "Add 2 referees to your application" %}
+  {% set incompleteLink = "/references/?referrer=" + referrer %}
+  {% include "_includes/review/incomplete.njk" %}
 {% endif %}

--- a/app/views/_includes/review/school-experience.njk
+++ b/app/views/_includes/review/school-experience.njk
@@ -1,7 +1,8 @@
 {% set applicationPath = "/application/" + applicationId %}
 {% set schoolExperience = applicationValue(["school-experience"]) %}
 
-{% if schoolExperience %}
+{% set complete = schoolExperience | length > 0 %}
+{% if complete %}
   {% set roles = schoolExperience | toArray | selectattr("id") | sort(attribute="start-date") %}
   {% if roles.length >= 1 %}
     {% for item in roles %}

--- a/app/views/_includes/review/school-experience.njk
+++ b/app/views/_includes/review/school-experience.njk
@@ -40,6 +40,7 @@
     }) }}
   {% endif %}
 {% else %}
+  {% set incompleteType = "warning" if errorList %}
   {% set incompleteId = "school-experience" %}
   {% set incompleteText = "Volunteering with children and young people is not marked as completed" %}
   {% set incompleteLink = "/school-experience?referrer=" + referrer %}

--- a/app/views/_includes/review/school-experience.njk
+++ b/app/views/_includes/review/school-experience.njk
@@ -12,10 +12,10 @@
         {{ item.role }}
         {%- if item["worked-with-children"] == "Yes" %}
         <span class="app-summary-card__meta">{{ appIcon({
-            classes: "govuk-!-margin-right-1",
-            icon: "tick",
-            hidden: true
-          }) }} This role involved working with children</span>
+          classes: "govuk-!-margin-right-1",
+          icon: "tick",
+          hidden: true
+        }) }} This role involved working with children</span>
         {%- endif %}
       {% endset %}
       {{ appSummaryCard({
@@ -40,5 +40,8 @@
     }) }}
   {% endif %}
 {% else %}
-  <p class="govuk-body">No school experiences entered.</p>
+  {% set incompleteId = "school-experience" %}
+  {% set incompleteText = "Volunteering with children and young people is not marked as completed" %}
+  {% set incompleteLink = "/school-experience?referrer=" + referrer %}
+  {% include "_includes/review/incomplete.njk" %}
 {% endif %}

--- a/app/views/_includes/review/subject-knowledge.njk
+++ b/app/views/_includes/review/subject-knowledge.njk
@@ -25,6 +25,7 @@
     html: subjectKnowledgeHtml
   }) }}
 {% else %}
+  {% set incompleteType = "warning" if errorList %}
   {% set incompleteId = "subject-knowledge" %}
   {% set incompleteText = "Tell us about your knowledge about the subject you want to teach" %}
   {% set incompleteLink = "/subject-knowledge?referrer=" + referrer %}

--- a/app/views/_includes/review/subject-knowledge.njk
+++ b/app/views/_includes/review/subject-knowledge.njk
@@ -25,5 +25,8 @@
     html: subjectKnowledgeHtml
   }) }}
 {% else %}
-  <p class="govuk-body">No subject knowledge entered.</p>
+  {% set incompleteId = "subject-knowledge" %}
+  {% set incompleteText = "Tell us about your knowledge about the subject you want to teach" %}
+  {% set incompleteLink = "/subject-knowledge?referrer=" + referrer %}
+  {% include "_includes/review/incomplete.njk" %}
 {% endif %}

--- a/app/views/_includes/review/subject-knowledge.njk
+++ b/app/views/_includes/review/subject-knowledge.njk
@@ -19,7 +19,8 @@
   }) }}
 {% endset %}
 
-{% if applicationValue(["subject-knowledge"]) %}
+{% set complete = applicationValue(["subject-knowledge"]) | length > 0 %}
+{% if complete %}
   {{ appSummaryCard({
     classes: "govuk-!-margin-bottom-6",
     html: subjectKnowledgeHtml

--- a/app/views/_includes/review/work-history.njk
+++ b/app/views/_includes/review/work-history.njk
@@ -170,5 +170,8 @@
     }) }}
   {% endif %}
 {% else %}
-  <p class="govuk-body">No work history entered.</p>
+  {% set incompleteId = "work-history" %}
+  {% set incompleteText = "Work history is not marked as completed" %}
+  {% set incompleteLink = "/work-history?referrer=" + referrer %}
+  {% include "_includes/review/incomplete.njk" %}
 {% endif %}

--- a/app/views/_includes/review/work-history.njk
+++ b/app/views/_includes/review/work-history.njk
@@ -170,6 +170,7 @@
     }) }}
   {% endif %}
 {% else %}
+  {% set incompleteType = "warning" if errorList %}
   {% set incompleteId = "work-history" %}
   {% set incompleteText = "Work history is not marked as completed" %}
   {% set incompleteLink = "/work-history?referrer=" + referrer %}

--- a/app/views/_includes/review/work-history.njk
+++ b/app/views/_includes/review/work-history.njk
@@ -1,7 +1,8 @@
 {% set applicationPath = "/application/" + applicationId %}
 {% set workHistory = applicationValue(["work-history"]) %}
 
-{% if workHistory %}
+{% set complete = workHistory | length > 0 %}
+{% if complete %}
   {% set history = workHistory | toArray | selectattr("id") | sort(attribute="start-date") %}
   {% if history.length >= 1 %}
     {% set hasAutomaticBreaks = data.flags.automatic_breaks == true %}

--- a/app/views/application/degree/review.njk
+++ b/app/views/application/degree/review.njk
@@ -22,32 +22,12 @@
     href: applicationPath + "/degree/add"
   }) }}
 
-  {# Only ask if want to add another if:
-    * not editing an existing item
-    * not referred from a review page (which has an ‘Add another…’ button)
-  #}
   {{ govukCheckboxes({
     items: [{
       value: "true",
       text: "I have completed this section"
     }]
   } | decorateApplicationAttributes(["completed", "degree"])) }}
-  {{ govukRadios({
-    name: "next",
-    fieldset: {
-      legend: {
-        text: "Do you want to add another degree?",
-        classes: "govuk-fieldset__legend--m"
-      }
-    },
-    items: [{
-      value: "add",
-      text: "Yes"
-    }, {
-      value: "review",
-      text: "No"
-    }]
-  }) }}
 
   {{ govukButton({
     text: "Continue"

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -56,12 +56,12 @@
     classes: "govuk-!-margin-bottom-8",
     items: [{
       text: "Personal details",
-      href: applicationPath + "/personal-details" + ("/review" if applicationValue(["candidate"])),
+      href: applicationPath + "/personal-details" + ("/review" if applicationValue(["candidate"]) | length > 0),
       id: "personal-details",
       tag: {
         classes: "app-tag--" + ("amended" if status == "amending" else "completed"),
         text: "Edited" if status == "amending" else "Completed"
-      } if applicationValue("candidate")
+      } if applicationValue(["candidate"]) | length > 0
     }, {
       text: "Contact details",
       href: applicationPath + "/contact-details" + ("/review" if applicationValue(["contact-details", "address"])),
@@ -72,7 +72,7 @@
       } if applicationValue(["contact-details", "address"])
     }, {
       text: "Work history",
-      href: applicationPath + "/work-history" + ("/review" if applicationValue("work-history")),
+      href: applicationPath + "/work-history" + ("/review" if applicationValue("work-history") | length > 0),
       id: "work-history",
       tag: {
         classes: tagClass,
@@ -80,7 +80,7 @@
       } if applicationValue(["completed", "work-history"])
     }, {
       text: "Volunteering with children and young people",
-      href: applicationPath + "/school-experience" + ("/review" if applicationValue("school-experience")),
+      href: applicationPath + "/school-experience" + ("/review" if applicationValue("school-experience") | length > 0),
       id: "school-experience",
       tag: {
         classes: tagClass,
@@ -88,12 +88,12 @@
       } if applicationValue(["completed", "school-experience"])
     }, {
      text: "Ask for help to become a teacher",
-     href: applicationPath + "/reasonable-adjustments" + ("/review" if applicationValue("reasonable-adjustments")),
+     href: applicationPath + "/reasonable-adjustments" + ("/review" if applicationValue("reasonable-adjustments") | length > 0),
      id: "reasonable-adjustments",
      tag: {
        classes: tagClass,
        text: tagText
-     } if applicationValue("reasonable-adjustments")
+     } if applicationValue("reasonable-adjustments") | length > 0
    }]
   }) }}
 
@@ -102,7 +102,7 @@
     classes: "govuk-!-margin-bottom-8",
     items: [{
       text: "Degree",
-      href: applicationPath + "/degree" + ("/review" if applicationValue(["degree"]) else "/add"),
+      href: applicationPath + "/degree" + ("/review" if applicationValue(["degree"]) | length > 0 else "/add"),
       id: "degree",
       tag: {
         classes: tagClass,
@@ -110,31 +110,31 @@
       } if applicationValue(["completed", "degree"])
     }, {
       text: "Maths GCSE or equivalent",
-      href: applicationPath + "/gcse/maths" + ("/review" if applicationValue(["gcse", "maths"])),
+      href: applicationPath + "/gcse/maths" + ("/review" if applicationValue(["gcse", "maths"]) | length > 0),
       id: "maths-gcse",
       tag: {
         classes: tagClass,
         text: tagText
-      } if applicationValue(["gcse", "maths"])
+      } if applicationValue(["gcse", "maths"]) | length > 0
     }, {
       text: "English GCSE or equivalent",
-      href: applicationPath + "/gcse/english" + ("/review" if applicationValue(["gcse", "english"])),
+      href: applicationPath + "/gcse/english" + ("/review" if applicationValue(["gcse", "english"]) | length > 0),
       id: "english-gcse",
       tag: {
         classes: tagClass,
         text: tagText
-      } if applicationValue(["gcse", "english"])
+      } if applicationValue(["gcse", "english"]) | length > 0
     }, {
       text: "Science GCSE or equivalent",
-      href: applicationPath + "/gcse/science" + ("/review" if applicationValue(["gcse", "science"])),
+      href: applicationPath + "/gcse/science" + ("/review" if applicationValue(["gcse", "science"]) | length > 0),
       id: "science-gcse",
       tag: {
         classes: tagClass,
         text: tagText
-      } if applicationValue(["gcse", "science"])
+      } if applicationValue(["gcse", "science"]) | length > 0
     } if hasPrimaryChoices() or applicationValue(["gcse", "science"]), {
       text: "Other relevant academic and non-academic qualifications",
-      href: applicationPath + "/other-qualifications" + ("/review" if applicationValue(["other-qualifications"]) else "/add"),
+      href: applicationPath + "/other-qualifications" + ("/review" if applicationValue(["other-qualifications"]) | length > 0 else "/add"),
       id: "other-qualifications",
       tag: {
         classes: tagClass,
@@ -148,28 +148,28 @@
     classes: "govuk-!-margin-bottom-8",
     items: [{
       text: "Why do you want to be a teacher?",
-      href: applicationPath + "/personal-statement" + ("/review" if applicationValue(["personal-statement"])),
+      href: applicationPath + "/personal-statement" + ("/review" if applicationValue(["personal-statement"]) | length > 0),
       id: "personal-statement",
       tag: {
         classes: tagClass,
         text: tagText
-      } if applicationValue(["personal-statement"])
+      } if applicationValue(["personal-statement"]) | length > 0
     }, {
       text: "Your knowledge about the subject you want to teach",
-      href: applicationPath + "/subject-knowledge" + ("/review" if applicationValue(["subject-knowledge"])),
+      href: applicationPath + "/subject-knowledge" + ("/review" if applicationValue(["subject-knowledge"]) | length > 0),
       id: "subject-knowledge",
       tag: {
         classes: tagClass,
         text: tagText
-      } if applicationValue(["subject-knowledge"])
+      } if applicationValue(["subject-knowledge"]) | length > 0
     }, {
       text: "Interview preferences",
-      href: applicationPath + "/interview" + ("/review" if applicationValue(["interview"])),
+      href: applicationPath + "/interview" + ("/review" if applicationValue(["interview"]) | length > 0),
       id: "interview",
       tag: {
         classes: tagClass,
         text: tagText
-      } if applicationValue(["interview-choice"])
+      } if applicationValue(["interview-choice"]) | length > 0
     } if data.flags.interview_preferences == true]
   }) }}
 
@@ -181,12 +181,12 @@
     classes: "govuk-!-margin-bottom-8",
     items: [{
       text: "Referees",
-      href: applicationPath + "/references" + ("/review" if applicationValue(["referees"])),
+      href: applicationPath + "/references" + ("/review" if applicationValue(["referees"]) | length > 0),
       id: "references",
       tag: {
         classes: "app-tag--" + ("completed" if status == "started" else ("submitted" if status == "amending")),
         text: "Completed" if status == "started" else ("Submitted" if status == "amending")
-      } if applicationValue(["referees"])
+      } if applicationValue(["referees"]) | length > 0
     }]
   }) }}
 

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -1,13 +1,11 @@
-{% extends "_content-wide.njk" %}
+{% extends "_form-wide.njk" %}
 
 {% set applicationPath = "/application/" + applicationId %}
+{% set formaction = applicationPath + "/review-complete" %}
 {% set status = applicationValue(["status"]) %}
 {% set title = "Review your application" %}
 {% set referrer = applicationPath + "/review" %}
 {% set canAmend = true %}
-
-{# Skip equality monitoring questions if amending application #}
-{% set nextHref = applicationPath + ("/submit" if applicationValue(["status"]) == "amending" else "/equality-monitoring") %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -17,7 +15,6 @@
 {% endblock %}
 
 {% block beforePageTitle %}
-
   {% if errorList %}
     {{ govukErrorSummary({
       titleText: "Your application cannot be submitted because it’s incomplete",
@@ -28,8 +25,7 @@
 
 {% block primary %}
   {{ govukWarningText({
-    text: "Please review your changes carefully before you resubmit. Your application can only be resubmitted once.",
-    iconFallbackText: "Warning"
+    text: "Please review your changes carefully before you resubmit. Your application can only be resubmitted once."
   }) if status == "amending" }}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
@@ -87,9 +83,7 @@
   {% set references = applicationValue(["referees"]) %}
   {% include "_includes/review/references.njk" %}
 
-  <form method="post">
-    {{ govukButton({
-      text: "Continue"
-    }) }}
-  </form>
+  {{ govukButton({
+    text: "Continue"
+  }) }}
 {% endblock %}

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -32,32 +32,10 @@
     iconFallbackText: "Warning"
   }) if status == "amending" }}
 
-  <h2 class="govuk-heading-m govuk-!-font-size-27">Course choices</h2>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
   {% set choices = applicationValue(["choices"]) | toArray %}
-
-  {% if choices.length %}
-    {% set showChoiceStatus = false %}
-    {% include "_includes/review/choices.njk" %}
-  {% else %}
-    {% set errorClass = "" %}
-    {% if errorList %}
-      {% set errorClass = " app-summary-card--error" %}
-    {% endif %}
-
-    {{ appSummaryCard({
-      attributes: {
-        id: 'choices-error'
-      },
-      classes: "app-summary-card--incomplete govuk-!-margin-bottom-6" + errorClass,
-      titleText: "Choices: section incomplete",
-      actions: {
-        items: [{
-          href: applicationPath + "/choices/add",
-          text: "Complete section"
-        }]
-      }
-    }) }}
-  {% endif %}
+  {% set showChoiceStatus = false %}
+  {% include "_includes/review/choices.njk" %}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
   <h3 class="govuk-heading-m">Personal details</h3>
@@ -66,6 +44,9 @@
   <h3 class="govuk-heading-m">Contact details</h3>
   {% set contactDetails = applicationValue(["contact-details"]) %}
   {% include "_includes/review/contact-details.njk" %}
+
+  <h3 class="govuk-heading-m">Ask for help to become a teacher</h3>
+  {% include "_includes/review/reasonable-adjustments.njk" %}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
   {% include "_includes/review/work-history.njk" %}
@@ -92,57 +73,16 @@
   {% endif %}
 
   <h3 class="govuk-heading-m">Other relevant qualifications</h3>
-  {% set qualifications = applicationValue(["other-qualifications"]) %}
-  {% set qualifications = qualifications | toArray | selectattr("id") %}
-  {% if qualifications.length %}
-    {% for item in qualifications %}
-      {% set qualificationHtml %}
-        {% include "_includes/item/other-qualification.njk" %}
-      {% endset %}
-      {{ appSummaryCard({
-        classes: "govuk-!-margin-bottom-6",
-        headingLevel: 3,
-        titleText: item.type + " " + item.subject,
-        actions: {
-          items: [{
-            href: applicationPath + "/other-qualifications/" + item.id + "/delete?referrer=" + referrer,
-            text: "Delete qualification"
-          }]
-        } if canAmend,
-        html: qualificationHtml
-      }) }}
-    {% endfor %}
-  {% else %}
-    {% set errorClass = "" %}
-    {% if errorList %}
-      {% set errorClass = " app-summary-card--error" %}
-    {% endif %}
-
-    {{ appSummaryCard({
-      attributes: {
-        id: 'other-qualifications-error'
-      },
-      classes: "app-summary-card--incomplete govuk-!-margin-bottom-6" + errorClass,
-      titleText: "Other relevant qualifications: section incomplete",
-      actions: {
-        items: [{
-          href: applicationPath + "/other-qualifications/add?referrer=" + referrer,
-          text: "Complete section"
-        }]
-      }
-    }) }}
-  {% endif %}
+  {% include "_includes/review/other-qualifications.njk" %}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement</h2>
   {% include "_includes/review/personal-statement.njk" %}
-  {% include "_includes/review/reasonable-adjustments.njk" %}
   {% include "_includes/review/subject-knowledge.njk" %}
   {% if data.flags.interview_preferences == true %}
     {% include "_includes/review/interview.njk" %}
   {% endif %}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
-  {# You can’t change your referees once application has been submitted #}
   {% set references = applicationValue(["referees"]) %}
   {% include "_includes/review/references.njk" %}
 

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -35,6 +35,7 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
   {% set choices = applicationValue(["choices"]) | toArray %}
   {% set showChoiceStatus = false %}
+  {% set showIncomplete = true %}
   {% include "_includes/review/choices.njk" %}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>

--- a/app/views/application/school-experience/index.njk
+++ b/app/views/application/school-experience/index.njk
@@ -5,10 +5,16 @@
 {% set formaction = applicationPath + "/school-experience/answer" %}
 
 {% block pageNavigation %}
-  {{ govukBackLink({
-    href: "/application/" + applicationId,
-    text: "Back to application"
-  }) }}
+  {% if referrer %}
+    {{ govukBackLink({
+      href: referrer
+    }) }}
+  {% else %}
+    {{ govukBackLink({
+      href: "/application/" + applicationId,
+      text: "Back to application"
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block primary %}

--- a/app/views/application/submitted.njk
+++ b/app/views/application/submitted.njk
@@ -26,7 +26,7 @@
     }]
   }) }}
 
-  <h2 class="govuk-heading-m govuk-!-font-size-27">Course choices</h2>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
   {% set choices = applicationValue(["choices"]) | toArray %}
   {% set showChoiceStatus = false %}
   {% include "_includes/review/choices.njk" %}
@@ -38,6 +38,9 @@
   <h3 class="govuk-heading-m">Contact details</h3>
   {% set contactDetails = applicationValue(["contact-details"]) %}
   {% include "_includes/review/contact-details.njk" %}
+
+  <h3 class="govuk-heading-m">Ask for help to become a teacher</h3>
+  {% include "_includes/review/reasonable-adjustments.njk" %}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
   {% include "_includes/review/work-history.njk" %}
@@ -71,7 +74,6 @@
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement</h2>
   {% include "_includes/review/personal-statement.njk" %}
-  {% include "_includes/review/reasonable-adjustments.njk" %}
   {% include "_includes/review/subject-knowledge.njk" %}
   {% if data.flags.interview_preferences == true %}
     {% include "_includes/review/interview.njk" %}

--- a/app/views/application/submitted.njk
+++ b/app/views/application/submitted.njk
@@ -48,9 +48,6 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27">Volunteering with children and young people</h2>
   {% include "_includes/review/school-experience.njk" %}
 
-  <h2 class="govuk-heading-m govuk-!-font-size-27">Training with a disability</h2>
-  {% include "_includes/review/disability.njk" %}
-
   <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
   <h3 class="govuk-heading-m">Degree(s)</h3>
   {% include "_includes/review/degrees.njk" %}

--- a/app/views/application/work-history/index.njk
+++ b/app/views/application/work-history/index.njk
@@ -4,10 +4,16 @@
 {% set formaction = applicationPath + "/work-history/answer" %}
 
 {% block pageNavigation %}
-  {{ govukBackLink({
-    href: "/application/" + applicationId,
-    text: "Back to application"
-  }) }}
+  {% if referrer %}
+    {{ govukBackLink({
+      href: referrer
+    }) }}
+  {% else %}
+    {{ govukBackLink({
+      href: "/application/" + applicationId,
+      text: "Back to application"
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block primary %}


### PR DESCRIPTION
* Fixes review page not being viewable
* Fixes review page not being submittable
* Fixes issue where trying to complete an incomplete GCSE or Degree from the review page, wouldn’t allow you to answer the follow on questions about year, grade etc (`referrer` took precedence. Now only directs to referrer if grade and year already have values).
* Updates CSS and markup for banner component to match that used on line service (including ability to display an icon)
* Uses banner component to show blue/red incomplete warnings on review page (better reflecting component used on live service)
* Updates section review includes to display new incomplete banners
* Updates incomplete messages to match those used on live service
* Updates routes for review pages to validate every section (and moves this logic into a separate file)
* When creating a new `application` object, populates it with empty objects and `null` values