### PR TITLE
Remove last catch-all question

### DIFF
--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -91,7 +91,6 @@ const hasCompletedApplication = req => {
     module.exports.hasCompletedSection(application.interview) &&
     module.exports.hasCompletedSection(application.referees)
   ) {
-    console.log('has completed application')
     return true
   }
 

--- a/app/views/application/submit.njk
+++ b/app/views/application/submit.njk
@@ -18,44 +18,14 @@
     <p class="govuk-body"><a href="https://www.gov.uk/exoffenders-and-employment">Learn more about telling an employer about your conviction</a>.</p>
   {% endset %}
 
-    <p>I understand I will have to undergo an enhanced <a href="https://www.gov.uk/government/organisations/disclosure-and-barring-service">Disclosure and Barring Check</a> as part of my application.</p>
-    {{ govukInsetText({
-      html: dbsCheckHtml
-    }) }}
+  <p>I understand I will have to undergo an enhanced <a href="https://www.gov.uk/government/organisations/disclosure-and-barring-service">Disclosure and Barring Check</a> as part of my application.</p>
+  {{ govukInsetText({
+    html: dbsCheckHtml
+  }) }}
 
-    {% set miscellaneousHtml %}
-      {{ govukCharacterCount({
-        label: {
-          text: "Enter further information"
-        },
-        rows: 10,
-        maxwords: 300
-      } | decorateApplicationAttributes(["miscellaneous"])) }}
-    {% endset %}
+  <p class="govuk-body">By submitting, I confirm that the information given is true, complete and accurate.</p>
 
-    {% set legendHtml %}
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Is there anything else you would like to tell us about your application?</h2>
-      <p class="govuk-body">Examples of further information include any disability, health or other personal or professional issue you feel is relevant to your application.</p>
-    {% endset %}
-    {{ govukRadios({
-      fieldset: {
-        legend: {
-          html: legendHtml
-        }
-      },
-      items: [{
-        text: "Yes",
-        conditional: {
-          html: miscellaneousHtml
-        }
-      }, {
-        text: "No"
-      }]
-    } | decorateApplicationAttributes(["miscellaneous-choice"])) }}
-
-    <p class="govuk-body">By submitting, I confirm that the information given is true, complete and accurate.</p>
-
-    {{ govukButton({
-      text: "Submit application"
-    }) }}
+  {{ govukButton({
+    text: "Submit application"
+  }) }}
 {% endblock %}


### PR DESCRIPTION
Prior to testing the training with a disability question, removing the ‘catch-all’ question that appears on the submit page, as this currently serves much of the same purpose. There are additional questions surrounding DBS checks, but those can be dealt with separately/later.

Updated page:

<img width="750" alt="Screenshot 2020-01-10 at 12 10 46" src="https://user-images.githubusercontent.com/813383/72152284-6fb3e300-33a2-11ea-9588-1fb26b739b39.png">
