### PR TITLE
Add section for suitability to work with children

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -172,6 +172,7 @@ module.exports = router => {
   require('./application/work-history')(router)
   require('./application/school-experience')(router)
   require('./application/reasonable-adjustments')(router)
+  require('./application/suitability')(router)
   require('./application/vocation')(router)
   require('./application/degree')(router)
   require('./application/gcse')(router)

--- a/app/routes/application/suitability.js
+++ b/app/routes/application/suitability.js
@@ -1,0 +1,27 @@
+/**
+ * Application: Suitability routes
+ */
+module.exports = router => {
+  // First page
+  router.get('/application/:applicationId/suitability', (req, res) => {
+    const referrer = req.query.referrer
+    const option = req.query.option || 'a'
+
+    res.render('application/suitability/index', {
+      referrer,
+      option,
+      formaction: `/application/${req.params.applicationId}/suitability/review`
+    })
+  })
+
+  // Render other reasonable adjustment pages
+  router.get('/application/:applicationId/suitability/:view', (req, res) => {
+    const { referrer } = req.query
+    const { option } = req.session.data
+
+    res.render(`application/suitability/${req.params.view}`, {
+      referrer,
+      option
+    })
+  })
+}

--- a/app/views/_includes/review/suitability.njk
+++ b/app/views/_includes/review/suitability.njk
@@ -1,0 +1,48 @@
+{% set applicationPath = "/application/" + applicationId %}
+{% set supportDetailsHtml %}
+  {{ govukSummaryList({
+    rows: [{
+      key: {
+        text: "Do you want to share any information which could have an impact on your application?"
+      },
+      value: {
+        text: "Yes" if applicationValue(["suitability", "disclose"]) == 'true' else 'No'
+      },
+      actions: {
+        items: [{
+          href: applicationPath + "/suitability?referrer=" + referrer,
+          text: "Change",
+          visuallyHiddenText: "whether you need to share something"
+        }]
+      } if canAmend
+    }, {
+      key: {
+        text: "Relevant information"
+      },
+      value: {
+        html: applicationValue(["suitability", "statement"])
+      },
+      actions: {
+        items: [{
+          href: applicationPath + "/suitability?referrer=" + referrer,
+          text: "Change",
+          visuallyHiddenText: "the information you are sharing"
+        }]
+      } if canAmend
+    } if applicationValue(["suitability", "disclose"]) == 'true']
+  }) }}
+{% endset %}
+
+{% set complete = applicationValue(["suitability"]) | length > 0 %}
+{% if complete %}
+  {{ appSummaryCard({
+    classes: "govuk-!-margin-bottom-6",
+    html: supportDetailsHtml
+  }) }}
+{% else %}
+  {% set incompleteType = "warning" if errorList %}
+  {% set incompleteId = "suitability" %}
+  {% set incompleteText = "No information entered" %}
+  {% set incompleteLink = "/suitability?referrer=" + referrer %}
+  {% include "_includes/review/incomplete.njk" %}
+{% endif %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -94,7 +94,15 @@
        classes: tagClass,
        text: tagText
      } if applicationValue("reasonable-adjustments") | length > 0
-   }]
+   }, {
+    text: "Your suitability to work with children",
+    href: applicationPath + "/suitability" + ("/review" if applicationValue("suitability") | length > 0),
+    id: "suitability",
+    tag: {
+      classes: tagClass,
+      text: tagText
+    } if applicationValue("suitability") | length > 0
+  }]
   }) }}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">Qualifications</h2>

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -45,6 +45,9 @@
   <h3 class="govuk-heading-m">Ask for help to become a teacher</h3>
   {% include "_includes/review/reasonable-adjustments.njk" %}
 
+  <h3 class="govuk-heading-m">Your suitability to work with children</h3>
+  {% include "_includes/review/suitability.njk" %}
+
   <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
   {% include "_includes/review/work-history.njk" %}
 

--- a/app/views/application/suitability/index.njk
+++ b/app/views/application/suitability/index.njk
@@ -1,0 +1,72 @@
+{% extends "_form.njk" %}
+
+{% set title = "Your suitability to work with children" %}
+
+{% block pageNavigation %}
+  {% if referrer %}
+    {{ govukBackLink({
+      href: referrer
+    }) }}
+  {% else %}
+    {{ govukBackLink({
+      href: "/application/" + applicationId,
+      text: "Back to application"
+    }) }}
+  {% endif %}
+{% endblock %}
+
+{% block primary %}
+<p class="govuk-body">
+  Everyone has to have an enhanced Disclosure and Barring Check (DBS check) before becoming a teacher. This shows your criminal record.
+</p>
+
+<p class="govuk-body">
+  Providers will also use other evidence and formal checks in the UK and abroad to decide if you’re suitable for teaching.
+</p>
+
+<p class="govuk-body">
+  If you’re concerned about something which could affect your application, you can talk to your provider about it.
+</p>
+
+<p class="govuk-body">
+  It won’t necessarily stop you from becoming a teacher. Showing honesty early on can help your application.
+</p>
+
+{% set disabilityConditional %}
+  {{ govukCharacterCount({
+    label: {
+      html: "Give any relevant information",
+      classes: "govuk-label--s"
+    },
+    maxwords: 400,
+    rows: 8
+  } | decorateApplicationAttributes(["suitability", "statement"])) }}
+{% endset %}
+
+{{ govukRadios({
+  fieldset: {
+    classes: "govuk-!-margin-top-6",
+    legend: {
+      text: "Do you want to share any information which could have an impact on your application?",
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  items: [{
+    value: "true",
+    text: "Yes, I want to share something",
+    hint: {
+      text: "You can tell us about it here or get in touch with your training provider directly."
+    },
+    conditional: {
+      html: disabilityConditional
+    }
+  }, {
+    value: "false",
+    text: "No"
+  }]
+} | decorateApplicationAttributes(["suitability", "disclose"])) }}
+
+{{ govukButton({
+  text: "Continue"
+}) }}
+{% endblock %}

--- a/app/views/application/suitability/index.njk
+++ b/app/views/application/suitability/index.njk
@@ -17,7 +17,7 @@
 
 {% block primary %}
 <p class="govuk-body">
-  Everyone has to have an enhanced Disclosure and Barring Check (DBS check) before becoming a teacher. This shows your criminal record.
+  Everyone has to have an enhanced <a href="https://www.gov.uk/government/organisations/disclosure-and-barring-service">Disclosure and Barring Check</a> (DBS check) before becoming a teacher. This shows your criminal record.
 </p>
 
 <p class="govuk-body">

--- a/app/views/application/suitability/review.njk
+++ b/app/views/application/suitability/review.njk
@@ -1,0 +1,21 @@
+{% extends "_content-wide.njk" %}
+
+{% set applicationPath = "/application/" + applicationId %}
+{% set referrer = applicationPath + "/suitability/review" %}
+{% set title = "Your suitability to work with children" %}
+{% set canAmend = true %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/application/" + applicationId,
+    text: "Back to application"
+  }) }}
+{% endblock %}
+
+{% block primary %}
+  {% include "_includes/review/suitability.njk" %}
+  {{ govukButton({
+    text: "Continue",
+    href: applicationPath
+  }) }}
+{% endblock %}


### PR DESCRIPTION
- Add section in personal details
- Model on disability section, making disclosure optional and encouraging conversation with providers
- Add a completed badge and show on final review
- Content from https://docs.google.com/document/d/1tpCtUbjjL5BBakBAaKEgawXHroUu4-YVU46e57dUM2w/edit

Im not sure what text we should use when the section hasn't been completed, no information entered is different to no decision made.

![localhost_3000_application_YHKCE_suitability](https://user-images.githubusercontent.com/319055/72545626-35a27f80-3881-11ea-8053-d4b2a3286c14.png)
![Screen Shot 2020-01-16 at 16 56 27](https://user-images.githubusercontent.com/319055/72545645-3c30f700-3881-11ea-8e13-5631400ddd78.png)
![Screen Shot 2020-01-16 at 16 56 20](https://user-images.githubusercontent.com/319055/72545647-3c30f700-3881-11ea-82de-50da127b97d2.png)
![Screen Shot 2020-01-16 at 16 55 26](https://user-images.githubusercontent.com/319055/72545648-3c30f700-3881-11ea-93b9-380a2640ea50.png)

https://trello.com/c/hkMU3bDS/744-re-evaluate-designs-for-criminal-conviction-declarations-feedback-from-providers

## Context

Universities have given us some "red flag" feedback that we are not doing enough to capture information about criminal convictions in our application form:

> A section for convictions or cautions? In regards to safeguarding and sex offences. They think it is good practice to ask this question. This seems to be a deal-breaker.

> A major red flag was that we don’t ask about unspent criminal convictions/ or if someone is on sex offender register. Although a DBS would filter out these candidates later down the line many interview days involve children and so an early q may filter out some unsuitable candidates. UCAS ask this q in some form.

> Would like crim record, honesty is important, they want it as an integrity check 

Providers interview before requesting a DBS check. Interviews will often involve working with children.