### PR TITLE
content change work history first sentence

### DIFF
--- a/app/views/application/work-history/job.njk
+++ b/app/views/application/work-history/job.njk
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">Please include all your paid work in school (for example as a teaching assistant) in this section.</p>
+  <p class="govuk-body">Please include all your paid work in this section.</p>
   <p class="govuk-body">Don’t include voluntary or unpaid experience – we’ll ask you about this in ‘Volunteering with children and young people’.</p>
   {{ govukInput({
     label: {


### PR DESCRIPTION
changed first sentence to 'Please include all your paid work in this section' to match live version. we changed this as it wasn't clear that we want to know about all paid work, as opposed to just paid work in a school