### PR TITLE
amended second sentence to reflect heading change of volunteering sec…

### DIFF
--- a/app/views/application/work-history/job.njk
+++ b/app/views/application/work-history/job.njk
@@ -18,8 +18,8 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">Please include all your paid work in this section.</p>
-  <p class="govuk-body">Don’t include voluntary or unpaid experience – we’ll ask you about this in ‘Volunteering with children and young people’.</p>
+  <p class="govuk-body">Include all your paid work in this section.</p>
+  <p class="govuk-body">Don’t include voluntary or unpaid experience – we'll ask about that later.</p>
   {{ govukInput({
     label: {
       text: "Job title",


### PR DESCRIPTION
…tion

we changed the heading of the volunteering section to 'unpaid experience and volunteering' so needed to change the content so that it longer referred to 'volunteering with children and young people'