### PR TITLE
Design for adding a replacement referee

### DIFF
--- a/app/views/application/references/alternative-review.njk
+++ b/app/views/application/references/alternative-review.njk
@@ -3,12 +3,9 @@
 {% set applicationPath = "/application/" + applicationId %}
 {% set referrer = applicationPath + "/references/review" %}
 
-{# You can’t amend your referees once application has been submitted #}
-{% set canAmend = true if not hasSubmittedApplications() %}
-
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: "/application/" + applicationId + "/references/alternative",
+    href: applicationPath + "/references/alternative",
     text: "Back"
   }) }}
 {% endblock %}
@@ -19,73 +16,61 @@
       <h1 class="govuk-heading-xl">Check your answers before&nbsp;confirming</h1>
     </div>
   </div>
-  {% set references = applicationValue(["referees"]) %}
-    {% set references = references | toArray %}
-    {% for item in references %}
-    {% set refereeHtml %}
 
-      {{ govukSummaryList({
-        rows: [{
-          key: {
-            text: "Name"
-          },
-          value: {
-            text: item.name or "Paul Jones"
-          },
-          actions: {
-            items: [{
-              href: applicationPath + "/references/details/" + item.id + "?referrer=" + referrer,
-              text: "Change",
-              visuallyHiddenText: "referee"
-            }]
-          } if canAmend
-        }, {
-          key: {
-            text: "Email"
-          },
-          value: {
-            text: item.email or "paul.jones@gov.uk"
-          },
-          actions: {
-            items: [{
-              href: applicationPath + "/references/details/" + item.id + "?referrer=" + referrer,
-              text: "Change",
-              visuallyHiddenText: "referee"
-            }]
-          } if canAmend
-        }, {
-          key: {
-            text: "Relationship"
-          },
-          value: {
-            text: (item.relationship or "My boss") | nl2br | safe
-          },
-          actions: {
-            items: [{
-              href: applicationPath + "/references/details/" + item.id + "?referrer=" + referrer,
-              text: "Change",
-              visuallyHiddenText: "referee"
-            }]
-          } if canAmend
-        }, {
-          key: {
-            text: "Status"
-          },
-          value: {
-            html: statusHtml
-          }
-        } if status and showReferenceStatus]
-      }) }}
-
-
-    {% endset %}
-    {{ appSummaryCard({
-      classes: "govuk-!-margin-bottom-6",
-      headingLevel: 3,
-      titleText: "New referee",
-      html: refereeHtml
+  {% set refereeHtml %}
+    {{ govukSummaryList({
+      rows: [{
+        key: {
+          text: "Name"
+        },
+        value: {
+          text: item.name or "Paul Jones"
+        },
+        actions: {
+          items: [{
+            href: applicationPath + "/references/alternative",
+            text: "Change",
+            visuallyHiddenText: "referee"
+          }]
+        }
+      }, {
+        key: {
+          text: "Email"
+        },
+        value: {
+          text: item.email or "paul.jones@gov.uk"
+        },
+        actions: {
+          items: [{
+            href: applicationPath + "/references/alternative",
+            text: "Change",
+            visuallyHiddenText: "referee"
+          }]
+        }
+      }, {
+        key: {
+          text: "Relationship"
+        },
+        value: {
+          text: (item.relationship or "My boss") | nl2br | safe
+        },
+        actions: {
+          items: [{
+            href: applicationPath + "/references/alternative",
+            text: "Change",
+            visuallyHiddenText: "referee"
+          }]
+        }
+      }]
     }) }}
-  {% endfor %}
+  {% endset %}
+
+  {{ appSummaryCard({
+    classes: "govuk-!-margin-bottom-6",
+    headingLevel: 3,
+    titleText: "New referee",
+    html: refereeHtml
+  }) }}
 
   <p class="govuk-body">We’ll contact your new referee immediately.</p>
 

--- a/app/views/application/references/alternative-review.njk
+++ b/app/views/application/references/alternative-review.njk
@@ -1,0 +1,96 @@
+{% extends "_content-wide.njk" %}
+
+{% set applicationPath = "/application/" + applicationId %}
+{% set referrer = applicationPath + "/references/review" %}
+
+{# You can’t amend your referees once application has been submitted #}
+{% set canAmend = true if not hasSubmittedApplications() %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: "/application/" + applicationId + "/references/alternative",
+    text: "Back"
+  }) }}
+{% endblock %}
+
+{% block primary %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Check your answers before&nbsp;confirming</h1>
+    </div>
+  </div>
+  {% set references = applicationValue(["referees"]) %}
+    {% set references = references | toArray %}
+    {% for item in references %}
+    {% set refereeHtml %}
+
+      {{ govukSummaryList({
+        rows: [{
+          key: {
+            text: "Name"
+          },
+          value: {
+            text: item.name or "Paul Jones"
+          },
+          actions: {
+            items: [{
+              href: applicationPath + "/references/details/" + item.id + "?referrer=" + referrer,
+              text: "Change",
+              visuallyHiddenText: "referee"
+            }]
+          } if canAmend
+        }, {
+          key: {
+            text: "Email"
+          },
+          value: {
+            text: item.email or "paul.jones@gov.uk"
+          },
+          actions: {
+            items: [{
+              href: applicationPath + "/references/details/" + item.id + "?referrer=" + referrer,
+              text: "Change",
+              visuallyHiddenText: "referee"
+            }]
+          } if canAmend
+        }, {
+          key: {
+            text: "Relationship"
+          },
+          value: {
+            text: (item.relationship or "My boss") | nl2br | safe
+          },
+          actions: {
+            items: [{
+              href: applicationPath + "/references/details/" + item.id + "?referrer=" + referrer,
+              text: "Change",
+              visuallyHiddenText: "referee"
+            }]
+          } if canAmend
+        }, {
+          key: {
+            text: "Status"
+          },
+          value: {
+            html: statusHtml
+          }
+        } if status and showReferenceStatus]
+      }) }}
+
+
+    {% endset %}
+    {{ appSummaryCard({
+      classes: "govuk-!-margin-bottom-6",
+      headingLevel: 3,
+      titleText: "New referee",
+      html: refereeHtml
+    }) }}
+  {% endfor %}
+
+  <p class="govuk-body">We’ll contact your new referee immediately.</p>
+
+  {{ govukButton({
+    text: "Confirm new referee",
+    href: applicationPath
+  }) }}
+{% endblock %}

--- a/app/views/application/references/alternative-review.njk
+++ b/app/views/application/references/alternative-review.njk
@@ -13,7 +13,7 @@
 {% block primary %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Check your answers before&nbsp;confirming</h1>
+      <h1 class="govuk-heading-xl">Check your referee’s details before confirming</h1>
     </div>
   </div>
 

--- a/app/views/application/references/alternative.njk
+++ b/app/views/application/references/alternative.njk
@@ -1,7 +1,7 @@
 {% extends "_form.njk" %}
 
 {% set type = applicationValue(["referees", id, "type"]) | lower %}
-{% set title = "Give details for your new referee" %}
+{% set title = "Add a new referee" %}
 {% set formaction = "/application/" + applicationId + "/references/alternative-review" %}
 
 {% block pageNavigation %}

--- a/app/views/application/references/alternative.njk
+++ b/app/views/application/references/alternative.njk
@@ -20,7 +20,7 @@
   <p class="govuk-body">Contact your referee in advance to check they are:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>happy to give you a reference</li>
-    <li>able to submit the reference within a reasonable timeframe</li>
+    <li>able to submit the reference as soon as possible</li>
     <li>comfortable submitting a reference online</li>
   </ul>
 

--- a/app/views/application/references/alternative.njk
+++ b/app/views/application/references/alternative.njk
@@ -1,0 +1,64 @@
+{% extends "_form.njk" %}
+
+{% set type = applicationValue(["referees", id, "type"]) | lower %}
+{% set title = "Give details for your new referee" %}
+{% set formaction = "/application/" + applicationId + "/references/alternative-review" %}
+
+{% block pageNavigation %}
+  {% if referrer %}
+    {{ govukBackLink({
+      href: referrer
+    }) }}
+  {% else %}
+    {{ govukBackLink({
+      href: "/application/" + applicationId + "/references/type/" + id
+    }) }}
+  {% endif %}
+{% endblock %}
+
+{% block primary %}
+  <p class="govuk-body">Contact your referee in advance to check they are:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>happy to give you a reference</li>
+    <li>able to submit the reference within a reasonable timeframe</li>
+    <li>comfortable submitting a reference online</li>
+  </ul>
+
+  {{ govukInput({
+    label: {
+      text: "Full name",
+      classes: "govuk-label--m govuk-!-margin-top-6"
+    }
+  } | decorateApplicationAttributes(["referees", id, "name"])) }}
+
+  {{ govukInput({
+    label: {
+      text: "Email address",
+      classes: "govuk-label--m"
+    }
+  } | decorateApplicationAttributes(["referees", id, "email"])) }}
+
+{% if type == "academic" %}
+  {% set relationshipExample = "They were my tutor at university from 2000 to 2003" %}
+{% elif type == "professional" %}
+  {% set relationshipExample = "I have been employed by them since January 2018" %}
+{% elif type == "school-based" %}
+  {% set relationshipExample = "I spent 2 weeks volunteering at their school in May 2019" %}
+{% else %}
+  {% set relationshipExample = "They were the headteacher at my secondary school between 2003 and 2005" %}
+{% endif %}
+
+  {{ govukCharacterCount({
+    label: {
+      text: "What is your relationship to this referee and how long have you known them?",
+      classes: "govuk-label--m"
+    },
+    hint: {
+      text: "For example, ‘" + relationshipExample + "’"
+    },
+    maxwords: 50
+  } | decorateApplicationAttributes(["referees", id, "relationship"])) }}
+  {{ govukButton({
+    text: "Continue"
+  }) }}
+{% endblock %}

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -39,6 +39,14 @@
   {% set showChoiceStatus = true %}
   {% set showReferenceStatus = true %}
 
+  {% set needsReferee = true %}
+  {% if needsReferee %}
+    {{ govukWarningText({
+      html: "You need to <a href=\"" + applicationPath + "/references/alternative" + "\">give details of a new referee</a>",
+      iconFallbackText: 'Warning'
+    }) }}
+  {% endif %}
+
   <h2 class="govuk-heading-m govuk-!-font-size-27">
   {% if canAmend %}
     Your application

--- a/app/views/applications/new-referee.njk
+++ b/app/views/applications/new-referee.njk
@@ -1,0 +1,23 @@
+{% extends "_content.njk" %}
+{% set applicationPath = "/application/12345" %}
+
+{% block primary %}
+  <h1 class="govuk-heading-xl">You need to give details of a new referee</h1>
+
+  {# <p>Our email requesting a reference didn’t reach Glinda Baumbach.</p> #}
+  {# <p>We haven’t had a reference from Doyle Denesik.</p> #}
+  <p>Carmel Kohler said they won’t give a reference.</p>
+
+  <p>We can’t send your application to your teacher training providers without 2 complete references.</p>
+
+  <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-4">
+    {{ govukButton({
+      text: "Give details of a new referee",
+      href: applicationPath + "/references/alternative"
+    }) }}
+  </div>
+
+  <p>
+    <a href="/applications">Continue without adding a referee</a>
+  </p>
+{% endblock %}

--- a/app/views/applications/new-referee.njk
+++ b/app/views/applications/new-referee.njk
@@ -2,7 +2,7 @@
 {% set applicationPath = "/application/12345" %}
 
 {% block primary %}
-  <h1 class="govuk-heading-xl">You need to give details of a new referee</h1>
+  <h1 class="govuk-heading-xl">You need to add a new referee</h1>
 
   {# <p>Our email requesting a reference didn’t reach Glinda Baumbach.</p> #}
   {# <p>We haven’t had a reference from Doyle Denesik.</p> #}
@@ -12,12 +12,12 @@
 
   <div class="govuk-!-margin-top-6 govuk-!-margin-bottom-4">
     {{ govukButton({
-      text: "Give details of a new referee",
+      text: "Add a new referee",
       href: applicationPath + "/references/alternative"
     }) }}
   </div>
 
   <p>
-    <a href="/applications">Continue without adding a referee</a>
+    <a href="/applications">Continue without adding a new referee</a>
   </p>
 {% endblock %}


### PR DESCRIPTION
Design outlined below.

What's missing:
- Updates to the emails we send out

Journeys:
```
Email asking for new referee > Click link > Sign in > Click sign in link > See ask for new details page
```

```
Homepage > Sign in > Click sign in link > See ask for new details page
```

### Ask for new details
- Show this page instead of the default home page
- Give reason why they need to replace referee, matching words used in emails
- Allow users to skip the step

![localhost_3000_applications_new-referee](https://user-images.githubusercontent.com/319055/73452180-42cf6c00-4361-11ea-9167-6527b5f58211.png)

### Give new details
- Same as referee form with minor changes
- Removes hint text about when we will contact them
- Has a descriptive title that matches button used to reach here (and no caption)

![localhost_3000_application_12345_references_alternative](https://user-images.githubusercontent.com/319055/73452193-495de380-4361-11ea-8ec2-868e3bc88b22.png)

### Confirm referee details before submitting
- Because the action is immediate, we will automatically email new referee, we need a review step
- Give the candidate a chance to catch any errors
- Confirming will send email and return user to application

![localhost_3000_application_12345_references_alternative-review](https://user-images.githubusercontent.com/319055/73452197-4c58d400-4361-11ea-9c0d-89bf78a5abd8.png)

### If they skip past the first screen
If they skipped the first screen, or didn't add a referee, maintain a warning on the dashboard

![localhost_3000_applications (1)](https://user-images.githubusercontent.com/319055/73452210-51b61e80-4361-11ea-87e8-ba063b901ddc.png)

