### PR TITLE
Update content on UCAS apply pages

### DIFF
--- a/app/routes/application/choices.js
+++ b/app/routes/application/choices.js
@@ -173,7 +173,8 @@ module.exports = router => {
 
   router.all('/application/:applicationId/choices/:choiceId/:view', (req, res) => {
     res.render(`application/choices/${req.params.view}`, {
-      paths: pickPaths(req)
+      paths: pickPaths(req),
+      found: temporaryChoice.found
     })
   })
 }

--- a/app/views/application/choices/pick.njk
+++ b/app/views/application/choices/pick.njk
@@ -9,7 +9,10 @@
 {% set provider = providers[providerCode] %}
 {% set providerOnDfEApply = false if providerCode == 'B20' else true %}
 {% set courses = provider.courses | toArray | sort(attribute="name") %}
-{% set title = "Which course are you applying to?" if providerOnDfEApply else "You need to apply on UCAS" %}
+{% if not providerOnDfEApply %}
+  {% set parent = "Primary (W1X1)" %}
+{% endif%}
+{% set title = "Which course are you applying to?" if providerOnDfEApply else "You need to apply for this course on UCAS" %}
 {% set formaction = paths.next %}
 {% set applicationPath = "/application/" + applicationId %}
 
@@ -51,23 +54,31 @@
       text: "Continue"
     }) }}
   {% else %}
-    <p>For now, the Department for Education’s Apply for teacher training service is limited to just a few training providers.</p>
-    <p>The training provider you’ve chosen is not signed up to the new service. This means you must apply for it using UCAS.</p>
-    <p>You’ll need to register with UCAS before you can apply.</p>
+    <p class="govuk-body">The provider you’ve chosen is not yet signed up to the new Apply for teacher training service. This means you must apply for it using UCAS.</p>
+    <p class="govuk-body">If your other preferred providers are signed up to the new service, it’s possible to apply through both systems. You can choose a total of 3 courses across both services.</p>
+    <p>For more information, see our <a href="https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training">Get into Teaching guidance on applying for teacher training</a>.</p>
 
-    <p class="govuk-body">You can also:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li><a href="https://getintoteaching.education.gov.uk/the-way-you-apply-for-teacher-training-is-changing">Learn more about changes to teacher training applications</a></li>
-      <li><a href="/apply/providers">Check the list of training providers</a> signed up to Apply for teacher training</li>
-    </ul>
-    <hr class="govuk-section-break govuk-section-break--l">
+    <h2 class="govuk-heading-m">Make a note of your course codes</h2>
+    <p>When you apply through UCAS, you’ll need these codes for the choices section of your application form:</p>
+
+    <div class="govuk-inset-text">
+      <ul class="govuk-list">
+        <li class="govuk-!-margin-bottom-2">
+          Training provider code:
+          <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold">{{ providerCode }}</span>
+        </li>
+        <li>
+          Training programme code:
+          <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold">W1X1</span>
+        </li>
+      </ul>
+    </div>
+
     <p class="govuk-body"><a href="https://2020.teachertraining.apply.ucas.com/apply/student/login.do" class="govuk-button govuk-!-margin-bottom-0">Apply on UCAS</a></p>
 
     {% if not applicationValue('welcomeFlow') %}
       <p class="govuk-body">or</p>
-      <p class="govuk-body">
-        <a href="{{ applicationPath }}" class="govuk-button govuk-button--secondary">Return to your application</a>
-      </p>
+      <p class="govuk-body"><a href="{{ applicationPath }}" class="govuk-link">Return to your application</a></p>
     {% endif %}
   {% endif %}
 {% endblock %}

--- a/app/views/apply/index.njk
+++ b/app/views/apply/index.njk
@@ -43,7 +43,21 @@
     {% endif %}
   {# Must apply through UCAS #}
   {% elif course and not dualRunning %}
-    <p class="govuk-body">You must apply for this course on UCAS. You’ll need to register with UCAS before you can apply.</p>
+    <p class="govuk-body">You must apply for this course on UCAS. You’ll need to register with UCAS before you can apply. Visit <a href="https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training">Get into Teaching for guidance on applying for teacher training</a>.</p>
+    <p>When you apply you’ll need these codes for the Choices section of your application form:</p>
+
+    <div class="govuk-inset-text">
+      <ul class="govuk-list">
+        <li class="govuk-!-margin-bottom-2">
+          Training provider code:
+          <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold">{{ providerCode }}</span>
+        </li>
+        <li>
+          Training programme code:
+          <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold">{{ courseCode }}</span>
+        </li>
+      </ul>
+    </div>
 
     {{ govukButton({
       text: "Apply through UCAS",


### PR DESCRIPTION
Updates the design of the page that candidates see if they select a course that’s not on Apply (within the Apply ‘choose a course’ journey). We may need to tweak the content to reassure candidates that they can use both services (picking three courses across both) if they so wish. /cc @emmajhf 

![Apply on UCAS](https://user-images.githubusercontent.com/813383/74953242-566a7180-53f9-11ea-967b-5ec62febb573.png)
