### PR TITLE
Hide disability and criminal convictions guidance from start page

### DIFF
--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -22,11 +22,13 @@
     <li class="govuk-body">undergo a <a href="https://www.gov.uk/dbs-check-applicant-criminal-record"> criminal record check</a></li>
   </ul>
 
+{# We will review the need for this guidance when we introduce these sections
   <h3 class="govuk-heading-m">If you have a criminal record</h3>
   <p class="govuk-body"><a href="https://www.gov.uk/exoffenders-and-employment">Not all convictions prevent you teaching.</a> If you have chosen a training provider, you can ask about their policy on criminal convictions.</p>
 
   <h3 class="govuk-heading-m">If you have a disability</h3>
   <p class="govuk-body">It’s unlawful to discriminate against you, and you don’t have to disclose a disability. <a href="/getintoteaching/train-to-teach-with-a-disability">Learn more about training to teach if you have a disability</a>.</p>
+#}
 
   <h3 class="govuk-heading-m">If you do not have a degree</h3>
   <p class="govuk-body">You can teach in further education (age 14 to adult), or <a href="https://getintoteaching.education.gov.uk/eligibility-for-teacher-training">study for a degree leading to qualified teacher status</a>.


### PR DESCRIPTION
We’ll review the need for including this guidance when we reintroduce these sections, but thinking is we don’t need to include this guidance here, at this point in the journey.

![Start page](https://user-images.githubusercontent.com/813383/74953876-27a0cb00-53fa-11ea-97e0-15dca5c93533.png)
