### PR TITLE
Alternative content for before you continue page

### DIFF
--- a/app/views/application/before-you-start.njk
+++ b/app/views/application/before-you-start.njk
@@ -1,6 +1,6 @@
 {% extends "_content.njk" %}
 
-{% set title = "Before you continue" %}
+{% set title = "We suggest you choose a course first" %}
 
 {% block beforePageTitle %}
   {{ appBanner({
@@ -11,15 +11,15 @@
 {% endblock %}
 
 {% block primary %}
-  <p>Apply for teacher training is a new GOV.UK service still in development.</p>
-  <p>The service will eventually replace UCAS as the way candidates apply for teacher training. However, for now, the service is limited to just a few courses.</p>
-  <p><strong>We suggest you choose a course first</strong>. That way, you’ll be able to check your course is available on the service before you fill out your application form.</p>
-  <p>If you choose a course which isn’t yet available on Apply for teacher training, you’ll be guided back to UCAS to make an application.</p>
+  <p>Apply for teacher training is a new GOV.UK service that will eventually replace UCAS. For now, you can only apply to some courses using this service.</p>
+  <p>By choosing a course first, you can check it’s available before you complete the rest of your application.</p>
+  <p>If you choose a course which is not available on Apply for teacher training, you’ll be guided back to UCAS to make an application.</p>
   <hr class="govuk-section-break govuk-section-break--m">
   {{ govukButton({
+    classes: "govuk-!-margin-bottom-5",
     text: "Choose a course",
     href: "/application/" + applicationId + "/choices/add"
   }) }}
   <p class="govuk-body">or</p>
-  <p class="govuk-body"><a href="/application/{{ applicationId }}">View the application form</a> to see what you’ll need to do to complete it.</p>
+  <p class="govuk-body"><a href="/application/{{ applicationId }}">Go to your application form</a></p>
 {% endblock %}


### PR DESCRIPTION
@emmajhf Me and @fofr played around with this page to make it less wordy and put the emphasis on the one message we want users to take away from this page, that we recommend that they choose a course first. Thoughts?

![Before you continue](https://user-images.githubusercontent.com/813383/74957268-38a00b00-53ff-11ea-8e6c-5263f8331beb.png)
