### PR TITLE
Stop people applying to courses that are full

### DIFF
--- a/app/assets/sass/components/_banner.scss
+++ b/app/assets/sass/components/_banner.scss
@@ -28,6 +28,12 @@
 
 .app-banner--info {
   border-color: govuk-colour("blue");
+
+  .app-banner__message {
+    @include govuk-typography-weight-bold;
+    color: govuk-colour("blue");
+    margin-bottom: govuk-spacing(3);
+  }
 }
 
 .app-banner--success {
@@ -46,8 +52,10 @@
   }
 
   &.app-banner--missing-section {
-    .app-banner__message p {
+    .app-banner__message {
+      @include govuk-typography-weight-bold;
       color: govuk-colour("red");
+      margin-bottom: govuk-spacing(3);
     }
   }
 }

--- a/app/routes/application/review.js
+++ b/app/routes/application/review.js
@@ -52,12 +52,12 @@ module.exports = router => {
       }
 
       pageObject.errorList.push({
-        text: 'Your course ‘Gorse SCITT – Primary (X100)’ has no vacancies',
+        text: 'You cannot apply to ‘Gorse SCITT – Primary (X100)’ because it has no vacancies',
         href: '#missing-blah'
       })
 
       pageObject.errorList.push({
-        text: 'Your course ‘Gorse SCITT – Primary (X100)’ is not running',
+        text: 'You cannot apply to ‘Gorse SCITT – Primary (X100)’ because it is not running',
         href: '#missing-blah'
       })
 

--- a/app/routes/application/review.js
+++ b/app/routes/application/review.js
@@ -9,7 +9,7 @@ module.exports = router => {
     var pageObject = {}
     var successFlash = req.flash('success')
 
-    if (successFlash[0] === 'submitted-incompleted-application') {
+    //if (successFlash[0] === 'submitted-incompleted-application') {
       pageObject.errorList = []
       const sections = {
         choices: 'Course choices not marked as completed',
@@ -50,7 +50,22 @@ module.exports = router => {
           }
         }
       }
-    }
+
+      pageObject.errorList.push({
+        text: 'Your course ‘Gorse SCITT – Primary (X100)’ has no vacancies',
+        href: '#missing-blah'
+      })
+
+      pageObject.errorList.push({
+        text: 'Your course ‘Gorse SCITT – Primary (X100)’ is not running',
+        href: '#missing-blah'
+      })
+
+      pageObject.errorList.push({
+        text: 'Your chosen location for ‘Gorse SCITT – Primary (X100)’ has no vacancies',
+        href: '#missing-blah'
+      })
+    //}
 
     res.render('application/review', pageObject)
   })

--- a/app/views/application/choices/full.njk
+++ b/app/views/application/choices/full.njk
@@ -1,0 +1,31 @@
+{% extends "_form.njk" %}
+
+{% set choices = applicationValue("choices") | toArray %}
+
+{% set count = choices.length %}
+{% set provider = providers[choices[count - 1].providerCode] %}
+{% set courseCode = choices[count - 1].courseCode %}
+{% set course = provider.courses[courseCode] %}
+
+{% set title = "You can’t apply to this course because it has no vacancies" %}
+
+{% set formaction = paths.current %}
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: paths.back
+  }) }}
+{% endblock %}
+
+{% block primary %}
+  <p>The course ‘Primary (X100)’ is full.</p>
+
+  <p>You can:</p>
+  <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+    <li><a href="#">go back and pick another course</a></li>
+    <li><a href="#">contact the training provider</a> to see if the course will re-open or discuss alternatives</li>
+  </ul>
+
+  {{ govukButton({
+    text: "Return to your application"
+  }) }}
+{% endblock %}

--- a/app/views/application/choices/full.njk
+++ b/app/views/application/choices/full.njk
@@ -7,7 +7,7 @@
 {% set courseCode = choices[count - 1].courseCode %}
 {% set course = provider.courses[courseCode] %}
 
-{% set title = "You can’t apply to this course because it has no vacancies" %}
+{% set title = "You cannot apply to this course because it has no vacancies" %}
 
 {% set formaction = paths.current %}
 {% block pageNavigation %}
@@ -21,11 +21,45 @@
 
   <p>You can:</p>
   <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
-    <li><a href="#">go back and pick another course</a></li>
-    <li><a href="#">contact the training provider</a> to see if the course will re-open or discuss alternatives</li>
+    <li><a href="#">choose another course</a></li>
+    <li>
+      <p>contact Gorse SCITT to see if the course will re-open or discuss alternatives</p>
+      {# <div class="govuk-inset-text">
+        <p>Telephone: 01234 321978<br/>Email: <a href="#">email@email.com</a></p>
+      </div> #}
+    </li>
   </ul>
 
-  {{ govukButton({
-    text: "Return to your application"
+  <h2 class="govuk-heading-m">Contact Gorse SCITT</h2>
+  {{ govukSummaryList({
+    rows: [
+      {
+        key: {
+          text: "Telephone"
+        },
+        value: {
+          text: "01234 321978"
+        }
+      },
+      {
+        key: {
+          text: "Email"
+        },
+        value: {
+          html: "<a href=\"#\">email@email.com</a>"
+        }
+      }
+    ]
   }) }}
+
+  {# {{ govukDetails({
+    summaryText: "Contact details",
+    html: "
+      <h3 class=\"govuk-heading-s\">Gorse SCITT</h3>
+      <p>Telephone: 01234 321978<br/>Email: <a href=\"#\">email@email.com</a></p>"
+  }) }} #}
+
+  <p class="govuk-!-margin-top-8">
+    <a href="#">Return to your application</a>
+  </p>
 {% endblock %}

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -17,7 +17,7 @@
 {% block beforePageTitle %}
   {% if errorList %}
     {{ govukErrorSummary({
-      titleText: "Your application cannot be submitted because it’s incomplete",
+      titleText: "There is a problem",
       errorList: errorList
     }) }}
   {% endif %}
@@ -29,6 +29,179 @@
   }) if status == "amending" }}
 
   <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
+
+  <div>
+    <section class="app-summary-card govuk-!-margin-bottom-6">
+      <header class="app-summary-card__header">
+        <h3 class="app-summary-card__title">
+          Gorse SCITT
+        </h3>
+        <div class="app-summary-card__actions">
+          <ul class="app-summary-card__actions-list">
+            <li class="app-summary-card__actions-list-item">
+              <a class="govuk-link" href="/application/12345/choices/ABCDE/delete?referrer=/application/12345/review">
+                    Delete choice</a>
+            </li>
+          </ul>
+        </div>
+      </header>
+      <div class="app-summary-card__body">
+        <div class="govuk-form-group govuk-form-group--error">
+          <span class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> You can’t apply to this course because it has no vacancies
+          </span>
+          <p>You can:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><a href="#">delete this choice</a> to submit your application.</li>
+            <li>choose another course</li>
+            <li><a href="#">contact the training provider</a> to see if the course will re-open or discuss alternatives</li>
+          </ul>
+        </div>
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Course
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <a href="https://find-postgraduate-teacher-training.education.gov.uk/course/1N1/2XT2">Primary (2XT2)</a><br>PGCE with QTS full time
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="/application/12345/choices/ABCDE/pick?referrer=/application/12345/review">
+                Change<span class="govuk-visually-hidden"> course</span>
+              </a>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Location
+            </dt>
+            <dd class="govuk-summary-list__value">
+              Hillcrest Academy<br>Cowper Street, Leeds. LS7 4DR
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="/application/12345/choices/ABCDE/location?referrer=/application/12345/review">
+                Change<span class="govuk-visually-hidden"> course location</span>
+              </a>
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+  </div>
+
+  <div>
+    <section class="app-summary-card govuk-!-margin-bottom-6">
+      <header class="app-summary-card__header">
+        <h3 class="app-summary-card__title">
+          Gorse SCITT
+        </h3>
+        <div class="app-summary-card__actions">
+          <ul class="app-summary-card__actions-list">
+            <li class="app-summary-card__actions-list-item">
+              <a class="govuk-link" href="/application/12345/choices/ABCDE/delete?referrer=/application/12345/review">
+                    Delete choice</a>
+            </li>
+          </ul>
+        </div>
+      </header>
+      <div class="app-summary-card__body">
+        <div class="govuk-form-group govuk-form-group--error">
+          <span class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> You can’t apply to this course because it is not running
+          </span>
+          <p>Gorse SCITT have decided not to run this course.</p>
+          <p>You can:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><a href="#">delete this choice</a> to submit your application.</li>
+            <li>choose another course</li>
+            <li><a href="#">contact the training provider</a> to discuss alternatives</li>
+          </ul>
+        </div>
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Course
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <a href="https://find-postgraduate-teacher-training.education.gov.uk/course/1N1/2XT2">Primary (2XT2)</a><br>PGCE with QTS full time
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="/application/12345/choices/ABCDE/pick?referrer=/application/12345/review">
+                Change<span class="govuk-visually-hidden"> course</span>
+              </a>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Location
+            </dt>
+            <dd class="govuk-summary-list__value">
+              Hillcrest Academy<br>Cowper Street, Leeds. LS7 4DR
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="/application/12345/choices/ABCDE/location?referrer=/application/12345/review">
+                Change<span class="govuk-visually-hidden"> course location</span>
+              </a>
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+  </div>
+
+  <div>
+    <section class="app-summary-card govuk-!-margin-bottom-6">
+      <header class="app-summary-card__header">
+        <h3 class="app-summary-card__title">
+          Gorse SCITT
+        </h3>
+        <div class="app-summary-card__actions">
+          <ul class="app-summary-card__actions-list">
+            <li class="app-summary-card__actions-list-item">
+              <a class="govuk-link" href="/application/12345/choices/ABCDE/delete?referrer=/application/12345/review">
+                    Delete choice</a>
+            </li>
+          </ul>
+        </div>
+      </header>
+      <div class="app-summary-card__body">
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Course
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <a href="https://find-postgraduate-teacher-training.education.gov.uk/course/1N1/2XT2">Primary (2XT2)</a><br>PGCE with QTS full time
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="/application/12345/choices/ABCDE/pick?referrer=/application/12345/review">
+                Change<span class="govuk-visually-hidden"> course</span>
+              </a>
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Location
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <div class="govuk-form-group govuk-form-group--error">
+                <span class="govuk-error-message">
+                  <span class="govuk-visually-hidden">Error:</span> No vacancies, pick a new location
+                </span>
+                Hillcrest Academy<br>Cowper Street, Leeds. LS7 4DR
+              </div>
+            </dd>
+            <dd class="govuk-summary-list__actions">
+              <a class="govuk-link" href="/application/12345/choices/ABCDE/location?referrer=/application/12345/review">
+                Change<span class="govuk-visually-hidden"> course location</span>
+              </a>
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+  </div>
+
   {% set choices = applicationValue(["choices"]) | toArray %}
   {% set showChoiceStatus = false %}
   {% set showIncomplete = true %}

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -31,7 +31,7 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
 
   <div>
-    <div class="app-banner app-banner--missing-section app-banner--warning govuk-!-padding-bottom-0">
+    <div class="app-banner app-banner--missing-section app-banner--warning govuk-!-padding-bottom-0 govuk-!-padding-right-0">
       <span class="app-banner__message">
         <span class="govuk-visually-hidden">Error:</span> You cannot apply to ‘Gorse SCITT – Primary (X100)’ because it has no vacancies
       </span>
@@ -91,7 +91,7 @@
   </div>
 
   <div>
-    <div class="app-banner app-banner--missing-section app-banner--info govuk-!-padding-bottom-0">
+    <div class="app-banner app-banner--missing-section app-banner--warning govuk-!-padding-bottom-0 govuk-!-padding-right-0">
       <span class="app-banner__message">
         <span class="govuk-visually-hidden">Error:</span> You cannot apply to ‘Gorse SCITT – Primary (X100)’ because it is not running
       </span>
@@ -152,10 +152,18 @@
   </div>
 
   <div>
-    <div class="app-banner app-banner--missing-section app-banner--info govuk-!-padding-bottom-0">
+    <div class="app-banner app-banner--missing-section app-banner--warning govuk-!-padding-bottom-0 govuk-!-padding-right-0">
       <span class="app-banner__message">
         <span class="govuk-visually-hidden">Error:</span> Your chosen location for ‘Gorse SCITT – Primary (X100)’ has no vacancies
       </span>
+
+      <p>You can:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><a href="#">pick a new location</a></li>
+        <li><a href="#">delete this choice</a></li>
+        <li><a href="#">change to another course</a></li>
+        <li><a href="#">contact the training provider</a> to discuss your options</li>
+      </ul>
 
       <section class="app-summary-card govuk-!-margin-bottom-3">
         <header class="app-summary-card__header">
@@ -195,7 +203,7 @@
               </dd>
               <dd class="govuk-summary-list__actions">
                 <a class="govuk-link" href="/application/12345/choices/ABCDE/location?referrer=/application/12345/review">
-                  Pick a new location
+                  Change
                 </a>
               </dd>
             </div>

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -31,175 +31,178 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
 
   <div>
-    <section class="app-summary-card govuk-!-margin-bottom-6">
-      <header class="app-summary-card__header">
-        <h3 class="app-summary-card__title">
-          Gorse SCITT
-        </h3>
-        <div class="app-summary-card__actions">
-          <ul class="app-summary-card__actions-list">
-            <li class="app-summary-card__actions-list-item">
-              <a class="govuk-link" href="/application/12345/choices/ABCDE/delete?referrer=/application/12345/review">
-                    Delete choice</a>
-            </li>
-          </ul>
-        </div>
-      </header>
-      <div class="app-summary-card__body">
-        <div class="govuk-form-group govuk-form-group--error">
-          <span class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span> You can’t apply to this course because it has no vacancies
-          </span>
-          <p>You can:</p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li><a href="#">delete this choice</a> to submit your application.</li>
-            <li>choose another course</li>
-            <li><a href="#">contact the training provider</a> to see if the course will re-open or discuss alternatives</li>
-          </ul>
-        </div>
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Course
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <a href="https://find-postgraduate-teacher-training.education.gov.uk/course/1N1/2XT2">Primary (2XT2)</a><br>PGCE with QTS full time
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="/application/12345/choices/ABCDE/pick?referrer=/application/12345/review">
-                Change<span class="govuk-visually-hidden"> course</span>
-              </a>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Location
-            </dt>
-            <dd class="govuk-summary-list__value">
-              Hillcrest Academy<br>Cowper Street, Leeds. LS7 4DR
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="/application/12345/choices/ABCDE/location?referrer=/application/12345/review">
-                Change<span class="govuk-visually-hidden"> course location</span>
-              </a>
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </section>
-  </div>
+    <div class="app-banner app-banner--missing-section app-banner--warning govuk-!-padding-bottom-0">
+      <span class="app-banner__message">
+        <span class="govuk-visually-hidden">Error:</span> You cannot apply to ‘Gorse SCITT – Primary (X100)’ because it has no vacancies
+      </span>
+      <p>You can:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><a href="#">delete this choice</a></li>
+        <li><a href="#">change to another course</a></li>
+        <li><a href="#">contact the training provider</a> to see if the course will re-open or discuss alternatives</li>
+      </ul>
 
-  <div>
-    <section class="app-summary-card govuk-!-margin-bottom-6">
-      <header class="app-summary-card__header">
-        <h3 class="app-summary-card__title">
-          Gorse SCITT
-        </h3>
-        <div class="app-summary-card__actions">
-          <ul class="app-summary-card__actions-list">
-            <li class="app-summary-card__actions-list-item">
-              <a class="govuk-link" href="/application/12345/choices/ABCDE/delete?referrer=/application/12345/review">
-                    Delete choice</a>
-            </li>
-          </ul>
-        </div>
-      </header>
-      <div class="app-summary-card__body">
-        <div class="govuk-form-group govuk-form-group--error">
-          <span class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span> You can’t apply to this course because it is not running
-          </span>
-          <p>Gorse SCITT have decided not to run this course.</p>
-          <p>You can:</p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li><a href="#">delete this choice</a> to submit your application.</li>
-            <li>choose another course</li>
-            <li><a href="#">contact the training provider</a> to discuss alternatives</li>
-          </ul>
-        </div>
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Course
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <a href="https://find-postgraduate-teacher-training.education.gov.uk/course/1N1/2XT2">Primary (2XT2)</a><br>PGCE with QTS full time
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="/application/12345/choices/ABCDE/pick?referrer=/application/12345/review">
-                Change<span class="govuk-visually-hidden"> course</span>
-              </a>
-            </dd>
+      <section class="app-summary-card govuk-!-margin-bottom-3">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Gorse SCITT
+          </h3>
+          <div class="app-summary-card__actions">
+            <ul class="app-summary-card__actions-list">
+              <li class="app-summary-card__actions-list-item">
+                <a class="govuk-link" href="/application/12345/choices/ABCDE/delete?referrer=/application/12345/review">
+                      Delete choice</a>
+              </li>
+            </ul>
           </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Location
-            </dt>
-            <dd class="govuk-summary-list__value">
-              Hillcrest Academy<br>Cowper Street, Leeds. LS7 4DR
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="/application/12345/choices/ABCDE/location?referrer=/application/12345/review">
-                Change<span class="govuk-visually-hidden"> course location</span>
-              </a>
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </section>
-  </div>
-
-  <div>
-    <section class="app-summary-card govuk-!-margin-bottom-6">
-      <header class="app-summary-card__header">
-        <h3 class="app-summary-card__title">
-          Gorse SCITT
-        </h3>
-        <div class="app-summary-card__actions">
-          <ul class="app-summary-card__actions-list">
-            <li class="app-summary-card__actions-list-item">
-              <a class="govuk-link" href="/application/12345/choices/ABCDE/delete?referrer=/application/12345/review">
-                    Delete choice</a>
-            </li>
-          </ul>
-        </div>
-      </header>
-      <div class="app-summary-card__body">
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Course
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <a href="https://find-postgraduate-teacher-training.education.gov.uk/course/1N1/2XT2">Primary (2XT2)</a><br>PGCE with QTS full time
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="/application/12345/choices/ABCDE/pick?referrer=/application/12345/review">
-                Change<span class="govuk-visually-hidden"> course</span>
-              </a>
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Location
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <div class="govuk-form-group govuk-form-group--error">
-                <span class="govuk-error-message">
-                  <span class="govuk-visually-hidden">Error:</span> No vacancies, pick a new location
-                </span>
+        </header>
+        <div class="app-summary-card__body">
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Course
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <a href="https://find-postgraduate-teacher-training.education.gov.uk/course/1N1/2XT2">Primary (2XT2)</a><br>PGCE with QTS full time
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="/application/12345/choices/ABCDE/pick?referrer=/application/12345/review">
+                  Change<span class="govuk-visually-hidden"> course</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Location
+              </dt>
+              <dd class="govuk-summary-list__value">
                 Hillcrest Academy<br>Cowper Street, Leeds. LS7 4DR
-              </div>
-            </dd>
-            <dd class="govuk-summary-list__actions">
-              <a class="govuk-link" href="/application/12345/choices/ABCDE/location?referrer=/application/12345/review">
-                Change<span class="govuk-visually-hidden"> course location</span>
-              </a>
-            </dd>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="/application/12345/choices/ABCDE/location?referrer=/application/12345/review">
+                  Change<span class="govuk-visually-hidden"> course location</span>
+                </a>
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <div>
+    <div class="app-banner app-banner--missing-section app-banner--info govuk-!-padding-bottom-0">
+      <span class="app-banner__message">
+        <span class="govuk-visually-hidden">Error:</span> You cannot apply to ‘Gorse SCITT – Primary (X100)’ because it is not running
+      </span>
+      <p>Gorse SCITT have decided not to run this course.</p>
+      <p>You can:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><a href="#">delete this choice</a></li>
+        <li><a href="#">change to another course</a></li>
+        <li><a href="#">contact the training provider</a> to discuss alternatives</li>
+      </ul>
+
+      <section class="app-summary-card govuk-!-margin-bottom-3">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Gorse SCITT
+          </h3>
+          <div class="app-summary-card__actions">
+            <ul class="app-summary-card__actions-list">
+              <li class="app-summary-card__actions-list-item">
+                <a class="govuk-link" href="/application/12345/choices/ABCDE/delete?referrer=/application/12345/review">
+                      Delete choice</a>
+              </li>
+            </ul>
           </div>
-        </dl>
-      </div>
-    </section>
+        </header>
+        <div class="app-summary-card__body">
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Course
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <a href="https://find-postgraduate-teacher-training.education.gov.uk/course/1N1/2XT2">Primary (2XT2)</a><br>PGCE with QTS full time
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="/application/12345/choices/ABCDE/pick?referrer=/application/12345/review">
+                  Change<span class="govuk-visually-hidden"> course</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Location
+              </dt>
+              <dd class="govuk-summary-list__value">
+                Hillcrest Academy<br>Cowper Street, Leeds. LS7 4DR
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="/application/12345/choices/ABCDE/location?referrer=/application/12345/review">
+                  Change<span class="govuk-visually-hidden"> course location</span>
+                </a>
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <div>
+    <div class="app-banner app-banner--missing-section app-banner--info govuk-!-padding-bottom-0">
+      <span class="app-banner__message">
+        <span class="govuk-visually-hidden">Error:</span> Your chosen location for ‘Gorse SCITT – Primary (X100)’ has no vacancies
+      </span>
+
+      <section class="app-summary-card govuk-!-margin-bottom-3">
+        <header class="app-summary-card__header">
+          <h3 class="app-summary-card__title">
+            Gorse SCITT
+          </h3>
+          <div class="app-summary-card__actions">
+            <ul class="app-summary-card__actions-list">
+              <li class="app-summary-card__actions-list-item">
+                <a class="govuk-link" href="/application/12345/choices/ABCDE/delete?referrer=/application/12345/review">
+                      Delete choice</a>
+              </li>
+            </ul>
+          </div>
+        </header>
+        <div class="app-summary-card__body">
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Course
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <a href="https://find-postgraduate-teacher-training.education.gov.uk/course/1N1/2XT2">Primary (2XT2)</a><br>PGCE with QTS full time
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="/application/12345/choices/ABCDE/pick?referrer=/application/12345/review">
+                  Change<span class="govuk-visually-hidden"> course</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Location
+              </dt>
+              <dd class="govuk-summary-list__value">
+                Hillcrest Academy<br>Cowper Street, Leeds. LS7 4DR
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="/application/12345/choices/ABCDE/location?referrer=/application/12345/review">
+                  Pick a new location
+                </a>
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+    </div>
   </div>
 
   {% set choices = applicationValue(["choices"]) | toArray %}


### PR DESCRIPTION
Note: Code is for example, don't expect to merge this PR.

This is the first part of the design process - stopping applications, before we look at warning people earlier:

## When people pick a course that's full, take them to this page

![Screen Shot 2020-02-28 at 14 00 24](https://user-images.githubusercontent.com/319055/75565429-d6ba5380-5a45-11ea-8c02-680f5c44ece3.png)

## When people pick a course that's no longer available

1. Course is now full
2. Course has been withdrawn
3. Location is now full

| Review | Validation |
|--|--|
|![localhost_3000_application_12345_review (1)](https://user-images.githubusercontent.com/319055/75565462-e20d7f00-5a45-11ea-92b4-e8fd6259dca2.png)|![localhost_3000_application_12345_review](https://user-images.githubusercontent.com/319055/75565472-e5a10600-5a45-11ea-8279-a5ab853ac1e0.png)|

https://trello.com/c/Ffktb1Rq/1098-stop-candidates-from-applying-to-courses-that-are-full-or-closed