### PR TITLE
Structured other qualifications

### DIFF
--- a/app/data/gcse-subjects.js
+++ b/app/data/gcse-subjects.js
@@ -1,0 +1,1117 @@
+module.exports = [{
+  value: '',
+  text: 'Select a country'
+}, {
+  value: 'Accounting',
+  text: 'Accounting'
+}, {
+  value: 'Additional Applied Science',
+  text: 'Additional Applied Science'
+}, {
+  value: 'Additional Mathematics (Pilot)',
+  text: 'Additional Mathematics (Pilot)'
+}, {
+  value: 'Additional Science',
+  text: 'Additional Science'
+}, {
+  value: 'Additional Science (Applied) (Pilot)',
+  text: 'Additional Science (Applied) (Pilot)'
+}, {
+  value: 'Additional Science (General) (Pilot)',
+  text: 'Additional Science (General) (Pilot)'
+}, {
+  value: 'Additional Science A',
+  text: 'Additional Science A'
+}, {
+  value: 'Additional Science B',
+  text: 'Additional Science B'
+}, {
+  value: 'Additional Science M (Modular)',
+  text: 'Additional Science M (Modular)'
+}, {
+  value: 'Agriculture and Land Use',
+  text: 'Agriculture and Land Use'
+}, {
+  value: 'Ancient History',
+  text: 'Ancient History'
+}, {
+  value: 'Ancient History (Short Course)',
+  text: 'Ancient History (Short Course)'
+}, {
+  value: 'Applications of Mathematics',
+  text: 'Applications of Mathematics'
+}, {
+  value: 'Applications of Mathematics (Pilot)',
+  text: 'Applications of Mathematics (Pilot)'
+}, {
+  value: 'Applied Art and Design (Double Award)',
+  text: 'Applied Art and Design (Double Award)'
+}, {
+  value: 'Applied Business',
+  text: 'Applied Business'
+}, {
+  value: 'Applied Business (Double Award)',
+  text: 'Applied Business (Double Award)'
+}, {
+  value: 'Applied Business (Double Award) (Pilot)',
+  text: 'Applied Business (Double Award) (Pilot)'
+}, {
+  value: 'Applied Business (Single Award)',
+  text: 'Applied Business (Single Award)'
+}, {
+  value: 'Applied Business A (Double Award)',
+  text: 'Applied Business A (Double Award)'
+}, {
+  value: 'Applied Business B (Double Award)',
+  text: 'Applied Business B (Double Award)'
+}, {
+  value: 'Applied French (Single Award)',
+  text: 'Applied French (Single Award)'
+}, {
+  value: 'Applied French: Oral Communication (Short Course)',
+  text: 'Applied French: Oral Communication (Short Course)'
+}, {
+  value: 'Applied French: Written Communication (Short Course)',
+  text: 'Applied French: Written Communication (Short Course)'
+}, {
+  value: 'Applied Information and Communication Technology (Double Award)',
+  text: 'Applied Information and Communication Technology (Double Award)'
+}, {
+  value: 'Applied Information and Communication Technology A (Double Award)',
+  text: 'Applied Information and Communication Technology A (Double Award)'
+}, {
+  value: 'Applied Information and Communication Technology B (Double Award)',
+  text: 'Applied Information and Communication Technology B (Double Award)'
+}, {
+  value: 'Applied Media (Double Award) (Pilot)',
+  text: 'Applied Media (Double Award) (Pilot)'
+}, {
+  value: 'Applied Media (Single Award) (Pilot)',
+  text: 'Applied Media (Single Award) (Pilot)'
+}, {
+  value: 'Applied Performing Arts (Double Award) (Pilot)',
+  text: 'Applied Performing Arts (Double Award) (Pilot)'
+}, {
+  value: 'Applied Performing Arts (Pilot)',
+  text: 'Applied Performing Arts (Pilot)'
+}, {
+  value: 'Applied Performing Arts (Single Award) (Pilot)',
+  text: 'Applied Performing Arts (Single Award) (Pilot)'
+}, {
+  value: 'Applied Physical Education (Double Award) (Pilot)',
+  text: 'Applied Physical Education (Double Award) (Pilot)'
+}, {
+  value: 'Applied Physical Education (Single Award) (Pilot)',
+  text: 'Applied Physical Education (Single Award) (Pilot)'
+}, {
+  value: 'Applied Science (Double Award)',
+  text: 'Applied Science (Double Award)'
+}, {
+  value: 'Arabic',
+  text: 'Arabic'
+}, {
+  value: 'Arabic: Spoken Language (Short Course)',
+  text: 'Arabic: Spoken Language (Short Course)'
+}, {
+  value: 'Arabic: Written Language (Short Course)',
+  text: 'Arabic: Written Language (Short Course)'
+}, {
+  value: 'Archaeology',
+  text: 'Archaeology'
+}, {
+  value: 'Art and Design',
+  text: 'Art and Design'
+}, {
+  value: 'Art and Design (Short Course)',
+  text: 'Art and Design (Short Course)'
+}, {
+  value: 'Astronomy',
+  text: 'Astronomy'
+}, {
+  value: 'Bengali',
+  text: 'Bengali'
+}, {
+  value: 'Bengali: Spoken Language (Short Course)',
+  text: 'Bengali: Spoken Language (Short Course)'
+}, {
+  value: 'Bengali: Written Language (Short Course)',
+  text: 'Bengali: Written Language (Short Course)'
+}, {
+  value: 'Biblical Hebrew',
+  text: 'Biblical Hebrew'
+}, {
+  value: 'Biology',
+  text: 'Biology'
+}, {
+  value: 'Biology (Human)',
+  text: 'Biology (Human)'
+}, {
+  value: 'Biology (Modular)',
+  text: 'Biology (Modular)'
+}, {
+  value: 'Biology A',
+  text: 'Biology A'
+}, {
+  value: 'Biology A (Gateway Science)',
+  text: 'Biology A (Gateway Science)'
+}, {
+  value: 'Biology B',
+  text: 'Biology B'
+}, {
+  value: 'Biology B (Twenty First Century Science)',
+  text: 'Biology B (Twenty First Century Science)'
+}, {
+  value: 'Biology M (Modular)',
+  text: 'Biology M (Modular)'
+}, {
+  value: 'Business',
+  text: 'Business'
+}, {
+  value: 'Business (Pilot)',
+  text: 'Business (Pilot)'
+}, {
+  value: 'Business and Communications Systems',
+  text: 'Business and Communications Systems'
+}, {
+  value: 'Business and Communication Systems',
+  text: 'Business and Communication Systems'
+}, {
+  value: 'Business Communications',
+  text: 'Business Communications'
+}, {
+  value: 'Business Studies',
+  text: 'Business Studies'
+}, {
+  value: 'Business Studies (Short Course)',
+  text: 'Business Studies (Short Course)'
+}, {
+  value: 'Business Studies (Short Course) (Pilot)',
+  text: 'Business Studies (Short Course) (Pilot)'
+}, {
+  value: 'Business Studies A',
+  text: 'Business Studies A'
+}, {
+  value: 'Business Studies and Economics',
+  text: 'Business Studies and Economics'
+}, {
+  value: 'Business Studies B',
+  text: 'Business Studies B'
+}, {
+  value: 'Business Studies B (Short Course)',
+  text: 'Business Studies B (Short Course)'
+}, {
+  value: 'Catering',
+  text: 'Catering'
+}, {
+  value: 'Chemistry',
+  text: 'Chemistry'
+}, {
+  value: 'Chemistry (Modular)',
+  text: 'Chemistry (Modular)'
+}, {
+  value: 'Chemistry A',
+  text: 'Chemistry A'
+}, {
+  value: 'Chemistry A (Gateway Science)',
+  text: 'Chemistry A (Gateway Science)'
+}, {
+  value: 'Chemistry B',
+  text: 'Chemistry B'
+}, {
+  value: 'Chemistry B (Twenty First Century Science)',
+  text: 'Chemistry B (Twenty First Century Science)'
+}, {
+  value: 'Chemistry M (Modular)',
+  text: 'Chemistry M (Modular)'
+}, {
+  value: 'Chinese',
+  text: 'Chinese'
+}, {
+  value: 'Chinese (Mandarin)',
+  text: 'Chinese (Mandarin)'
+}, {
+  value: 'Chinese (Mandarin): Spoken Language (Short Course)',
+  text: 'Chinese (Mandarin): Spoken Language (Short Course)'
+}, {
+  value: 'Chinese (Mandarin): Written Language (Short Course)',
+  text: 'Chinese (Mandarin): Written Language (Short Course)'
+}, {
+  value: 'Chinese (Spoken Mandarin)',
+  text: 'Chinese (Spoken Mandarin)'
+}, {
+  value: 'Chinese (Spoken Mandarin/Spoken Cantonese)',
+  text: ''
+}, {
+  value: 'Chinese: Spoken Language (Short Course)',
+  text: 'Chinese: Spoken Language (Short Course)'
+}, {
+  value: 'Chinese: Written Language (Short Course)',
+  text: 'Chinese: Written Language (Short Course)'
+}, {
+  value: 'Citizenship Studies',
+  text: 'Citizenship Studies'
+}, {
+  value: 'Citizenship Studies (Short Course)',
+  text: 'Citizenship Studies (Short Course)'
+}, {
+  value: 'Classical Civilisation',
+  text: 'Classical Civilisation'
+}, {
+  value: 'Classical Civilisation (Short Course)',
+  text: 'Classical Civilisation (Short Course)'
+}, {
+  value: 'Classical Greek',
+  text: 'Classical Greek'
+}, {
+  value: 'Classical Greek (Short Course)',
+  text: 'Classical Greek (Short Course)'
+}, {
+  value: 'Combined Science',
+  text: 'Combined Science'
+}, {
+  value: 'Combined Science: Synergy',
+  text: 'Combined Science: Synergy'
+}, {
+  value: 'Combined Science: Trilogy',
+  text: 'Combined Science: Trilogy'
+}, {
+  value: 'Combined Science A (Gateway Science)',
+  text: 'Combined Science A (Gateway Science)'
+}, {
+  value: 'Combined Science B (Twenty First Century Science)',
+  text: 'Combined Science B (Twenty First Century Science)'
+}, {
+  value: 'Computer Science',
+  text: 'Computer Science'
+}, {
+  value: 'Computing',
+  text: 'Computing'
+}, {
+  value: 'Construction (Pilot)',
+  text: 'Construction (Pilot)'
+}, {
+  value: 'Construction and the Built Environment',
+  text: 'Construction and the Built Environment'
+}, {
+  value: 'Construction and the Built Environment (Double Award) (Pilot)',
+  text: 'Construction and the Built Environment (Double Award) (Pilot)'
+}, {
+  value: 'Construction and the Built Environment (Pilot)',
+  text: 'Construction and the Built Environment (Pilot)'
+}, {
+  value: 'Contemporary Crafts',
+  text: 'Contemporary Crafts'
+}, {
+  value: 'Cymraeg',
+  text: 'Cymraeg'
+}, {
+  value: 'Cymraeg (Peilot)',
+  text: 'Cymraeg (Peilot)'
+}, {
+  value: 'Cymraeg Ail Iaith',
+  text: 'Cymraeg Ail Iaith'
+}, {
+  value: 'Cymraeg Ail Iaith (Short Course)',
+  text: 'Cymraeg Ail Iaith (Short Course)'
+}, {
+  value: 'Cymraeg Ail Iaith Cymhwysol',
+  text: 'Cymraeg Ail Iaith Cymhwysol'
+}, {
+  value: 'Cymraeg Ail Iaith Cymhwysol (Short Course)',
+  text: 'Cymraeg Ail Iaith Cymhwysol (Short Course)'
+}, {
+  value: 'Cymraeg Iaith',
+  text: 'Cymraeg Iaith'
+}, {
+  value: 'Dance',
+  text: 'Dance'
+}, {
+  value: 'Design and Technology',
+  text: 'Design and Technology'
+}, {
+  value: 'Design and Technology (Electronic Products)',
+  text: 'Design and Technology (Electronic Products)'
+}, {
+  value: 'Design and Technology (Food Technology)',
+  text: 'Design and Technology (Food Technology)'
+}, {
+  value: 'Design and Technology (Graphic Products)',
+  text: 'Design and Technology (Graphic Products)'
+}, {
+  value: 'Design and Technology (Pilot)',
+  text: 'Design and Technology (Pilot)'
+}, {
+  value: 'Design and Technology (Product Design)',
+  text: 'Design and Technology (Product Design)'
+}, {
+  value: 'Design and Technology (Product Design) (Short Course)',
+  text: 'Design and Technology (Product Design) (Short Course)'
+}, {
+  value: 'Design and Technology (Resistant Materials Technology)',
+  text: 'Design and Technology (Resistant Materials Technology)'
+}, {
+  value: 'Design and Technology (Short Course)',
+  text: 'Design and Technology (Short Course)'
+}, {
+  value: 'Design and Technology (Systems and Control Technology)',
+  text: 'Design and Technology (Systems and Control Technology)'
+}, {
+  value: 'Design and Technology (Textiles Technology)',
+  text: 'Design and Technology (Textiles Technology)'
+}, {
+  value: 'Digital Communication (Pilot)',
+  text: 'Digital Communication (Pilot)'
+}, {
+  value: 'Digital Technology',
+  text: 'Digital Technology'
+}, {
+  value: 'Double Award Science',
+  text: 'Double Award Science'
+}, {
+  value: 'Double Award Science (Double Award)',
+  text: 'Double Award Science (Double Award)'
+}, {
+  value: 'Drama',
+  text: 'Drama'
+}, {
+  value: 'Dutch',
+  text: 'Dutch'
+}, {
+  value: 'Dutch: Spoken Language (Short Course)',
+  text: 'Dutch: Spoken Language (Short Course)'
+}, {
+  value: 'Dutch: Written Language (Short Course)',
+  text: 'Dutch: Written Language (Short Course)'
+}, {
+  value: 'Economics',
+  text: 'Economics'
+}, {
+  value: 'Economics (Short Course)',
+  text: 'Economics (Short Course)'
+}, {
+  value: 'Electronics',
+  text: 'Electronics'
+}, {
+  value: 'Electronics (Short Course)',
+  text: 'Electronics (Short Course)'
+}, {
+  value: 'Engineering',
+  text: 'Engineering'
+}, {
+  value: 'Engineering (Double Award)',
+  text: 'Engineering (Double Award)'
+}, {
+  value: 'Engineering and Manufacturing',
+  text: 'Engineering and Manufacturing'
+}, {
+  value: 'English',
+  text: 'English'
+}, {
+  value: 'English (Double Award) (Pilot)',
+  text: 'English (Double Award) (Pilot)'
+}, {
+  value: 'English (Pilot)',
+  text: 'English (Pilot)'
+}, {
+  value: 'English (Single Award) (Pilot)',
+  text: 'English (Single Award) (Pilot)'
+}, {
+  value: 'English - Communication (Short Course) (Pilot)',
+  text: ''
+}, {
+  value: 'English - Drama and Prose (Short Course) (Pilot)',
+  text: ''
+}, {
+  value: 'English - Spoken English Studies (Short Course) (Pilot)',
+  text: ''
+}, {
+  value: 'English - The Language of Digital Communication (Short Course) (Pilot)',
+  text: ''
+}, {
+  value: 'English - The Moving Image (Short Course) (Pilot)',
+  text: ''
+}, {
+  value: 'English A',
+  text: 'English A'
+}, {
+  value: 'English B',
+  text: 'English B'
+}, {
+  value: 'English Language',
+  text: 'English Language'
+}, {
+  value: 'English Language A',
+  text: 'English Language A'
+}, {
+  value: 'English Literature',
+  text: 'English Literature'
+}, {
+  value: 'English Literature (Single Award) (Pilot)',
+  text: 'English Literature (Single Award) (Pilot)'
+}, {
+  value: 'English Literature A',
+  text: 'English Literature A'
+}, {
+  value: 'English Literature B',
+  text: 'English Literature B'
+}, {
+  value: 'English Studies (Double Award) (Pilot)',
+  text: 'English Studies (Double Award) (Pilot)'
+}, {
+  value: 'English Studies (Single Award) (Pilot)',
+  text: 'English Studies (Single Award) (Pilot)'
+}, {
+  value: 'Environmental and Land-Based Science',
+  text: ''
+}, {
+  value: 'Environmental Science',
+  text: 'Environmental Science'
+}, {
+  value: 'Expressive Arts',
+  text: 'Expressive Arts'
+}, {
+  value: 'Film Studies',
+  text: 'Film Studies'
+}, {
+  value: 'Film Studies (Pilot)',
+  text: 'Film Studies (Pilot)'
+}, {
+  value: 'Financial Services (Pilot)',
+  text: 'Financial Services (Pilot)'
+}, {
+  value: 'Food and Nutrition',
+  text: 'Food and Nutrition'
+}, {
+  value: 'Food Preparation and Nutrition',
+  text: 'Food Preparation and Nutrition'
+}, {
+  value: 'French',
+  text: 'French'
+}, {
+  value: 'French (Short Course)',
+  text: 'French (Short Course)'
+}, {
+  value: 'French: Spoken Language (Short Course)',
+  text: 'French: Spoken Language (Short Course)'
+}, {
+  value: 'French: Written Language (Short Course)',
+  text: 'French: Written Language (Short Course)'
+}, {
+  value: 'French A',
+  text: 'French A'
+}, {
+  value: 'French A (Short Course)',
+  text: 'French A (Short Course)'
+}, {
+  value: 'French B',
+  text: 'French B'
+}, {
+  value: 'Further Additional Science',
+  text: 'Further Additional Science'
+}, {
+  value: 'Further Additional Science A',
+  text: 'Further Additional Science A'
+}, {
+  value: 'Further Additional Science B',
+  text: 'Further Additional Science B'
+}, {
+  value: 'Further Mathematics',
+  text: 'Further Mathematics'
+}, {
+  value: 'Gaeilge',
+  text: 'Gaeilge'
+}, {
+  value: 'General Studies',
+  text: 'General Studies'
+}, {
+  value: 'Geography',
+  text: 'Geography'
+}, {
+  value: 'Geography (Pilot)',
+  text: 'Geography (Pilot)'
+}, {
+  value: 'Geography (Short Course)',
+  text: 'Geography (Short Course)'
+}, {
+  value: 'Geography A',
+  text: 'Geography A'
+}, {
+  value: 'Geography A (Geographical Themes)',
+  text: 'Geography A (Geographical Themes)'
+}, {
+  value: 'Geography A (Short Course)',
+  text: 'Geography A (Short Course)'
+}, {
+  value: 'Geography A Modular',
+  text: 'Geography A Modular'
+}, {
+  value: 'Geography B',
+  text: 'Geography B'
+}, {
+  value: 'Geography B (Geography for Enquiring Minds)',
+  text: 'Geography B (Geography for Enquiring Minds)'
+}, {
+  value: 'Geography B (Short Course)',
+  text: 'Geography B (Short Course)'
+}, {
+  value: 'Geography C',
+  text: 'Geography C'
+}, {
+  value: 'Geography C (Short Course)',
+  text: 'Geography C (Short Course)'
+}, {
+  value: 'Geology',
+  text: 'Geology'
+}, {
+  value: 'German',
+  text: 'German'
+}, {
+  value: 'German (Short Course)',
+  text: 'German (Short Course)'
+}, {
+  value: 'German: Spoken Language (Short Course)',
+  text: 'German: Spoken Language (Short Course)'
+}, {
+  value: 'German: Written Language (Short Course)',
+  text: 'German: Written Language (Short Course)'
+}, {
+  value: 'German A',
+  text: 'German A'
+}, {
+  value: 'German A (Short Course)',
+  text: 'German A (Short Course)'
+}, {
+  value: 'German B',
+  text: 'German B'
+}, {
+  value: 'Government and Politics',
+  text: 'Government and Politics'
+}, {
+  value: 'Greek',
+  text: 'Greek'
+}, {
+  value: 'Greek: Spoken Language (Short Course)',
+  text: 'Greek: Spoken Language (Short Course)'
+}, {
+  value: 'Greek: Written Language (Short Course)',
+  text: 'Greek: Written Language (Short Course)'
+}, {
+  value: 'Gujarati',
+  text: 'Gujarati'
+}, {
+  value: 'Gujarati: Spoken Language (Short Course)',
+  text: 'Gujarati: Spoken Language (Short Course)'
+}, {
+  value: 'Gujarati: Written Language (Short Course)',
+  text: 'Gujarati: Written Language (Short Course)'
+}, {
+  value: 'Health and Social Care',
+  text: 'Health and Social Care'
+}, {
+  value: 'Health and Social Care (Double Award)',
+  text: 'Health and Social Care (Double Award)'
+}, {
+  value: 'History',
+  text: 'History'
+}, {
+  value: 'History (Pilot)',
+  text: 'History (Pilot)'
+}, {
+  value: 'History (Short Course)',
+  text: 'History (Short Course)'
+}, {
+  value: 'History (Short Course) (Pilot)',
+  text: 'History (Short Course) (Pilot)'
+}, {
+  value: 'History A',
+  text: 'History A'
+}, {
+  value: 'History A (Explaining the Modern World)',
+  text: 'History A (Explaining the Modern World)'
+}, {
+  value: 'History A (Short Course)',
+  text: 'History A (Short Course)'
+}, {
+  value: 'History B',
+  text: 'History B'
+}, {
+  value: 'History B (Schools History Project)',
+  text: 'History B (Schools History Project)'
+}, {
+  value: 'History B (Short Course)',
+  text: 'History B (Short Course)'
+}, {
+  value: 'History C',
+  text: 'History C'
+}, {
+  value: 'History C (Short Course)',
+  text: 'History C (Short Course)'
+}, {
+  value: 'Home Economics',
+  text: 'Home Economics'
+}, {
+  value: 'Home Economics (Child Development)',
+  text: 'Home Economics (Child Development)'
+}, {
+  value: 'Home Economics (Food and Nutrition)',
+  text: 'Home Economics (Food and Nutrition)'
+}, {
+  value: 'Home Economics (Textiles)',
+  text: 'Home Economics (Textiles)'
+}, {
+  value: 'Hospitality',
+  text: 'Hospitality'
+}, {
+  value: 'Hospitality (Pilot)',
+  text: 'Hospitality (Pilot)'
+}, {
+  value: 'Hospitality and Catering (Double Award)',
+  text: 'Hospitality and Catering (Double Award)'
+}, {
+  value: 'Hospitality and Catering (Single Award)',
+  text: 'Hospitality and Catering (Single Award)'
+}, {
+  value: 'Human Health and Physiology',
+  text: 'Human Health and Physiology'
+}, {
+  value: 'Humanities',
+  text: 'Humanities'
+}, {
+  value: 'Human Physiology and Health',
+  text: 'Human Physiology and Health'
+}, {
+  value: 'Information and Communication Technology',
+  text: 'Information and Communication Technology'
+}, {
+  value: 'Information and Communication Technology (Double Award)',
+  text: 'Information and Communication Technology (Double Award)'
+}, {
+  value: 'Information and Communication Technology (Full Course)',
+  text: 'Information and Communication Technology (Full Course)'
+}, {
+  value: 'Information and Communication Technology (Pilot)',
+  text: 'Information and Communication Technology (Pilot)'
+}, {
+  value: 'Information and Communication Technology (Short Course)',
+  text: 'Information and Communication Technology (Short Course)'
+}, {
+  value: 'Information and Communication Technology A',
+  text: 'Information and Communication Technology A'
+}, {
+  value: 'Information and Communication Technology A (Short Course)',
+  text: 'Information and Communication Technology A (Short Course)'
+}, {
+  value: 'Information and Communication Technology B',
+  text: 'Information and Communication Technology B'
+}, {
+  value: 'Information and Communication Technology B (Short Course)',
+  text: 'Information and Communication Technology B (Short Course)'
+}, {
+  value: 'Irish',
+  text: 'Irish'
+}, {
+  value: 'Irish: Spoken Language (Short Course)',
+  text: 'Irish: Spoken Language (Short Course)'
+}, {
+  value: 'Irish: Written Language (Short Course)',
+  text: 'Irish: Written Language (Short Course)'
+}, {
+  value: 'Italian',
+  text: 'Italian'
+}, {
+  value: 'Italian: Spoken Language (Short Course)',
+  text: 'Italian: Spoken Language (Short Course)'
+}, {
+  value: 'Italian: Written Language (Short Course)',
+  text: 'Italian: Written Language (Short Course)'
+}, {
+  value: 'Japanese',
+  text: 'Japanese'
+}, {
+  value: 'Japanese: Spoken Language (Short Course)',
+  text: 'Japanese: Spoken Language (Short Course)'
+}, {
+  value: 'Japanese: Written Language (Short Course)',
+  text: 'Japanese: Written Language (Short Course)'
+}, {
+  value: 'Journalism (Pilot)',
+  text: 'Journalism (Pilot)'
+}, {
+  value: 'Journalism in the Media and Communications Industry',
+  text: 'Journalism in the Media and Communications Industry'
+}, {
+  value: 'Latin',
+  text: 'Latin'
+}, {
+  value: 'Latin (Short Course)',
+  text: 'Latin (Short Course)'
+}, {
+  value: 'Law',
+  text: 'Law'
+}, {
+  value: 'Learning for Life and Work',
+  text: 'Learning for Life and Work'
+}, {
+  value: 'Learning for Life and Work (Pilot)',
+  text: 'Learning for Life and Work (Pilot)'
+}, {
+  value: 'Leisure',
+  text: 'Leisure Travel and Tourism'
+}, {
+  value: 'Leisure and Tourism',
+  text: 'Leisure and Tourism'
+}, {
+  value: 'Leisure and Tourism (Double Award)',
+  text: 'Leisure and Tourism (Double Award)'
+}, {
+  value: 'Llenyddiaeth Gymraeg',
+  text: 'Llenyddiaeth Gymraeg'
+}, {
+  value: 'Manufacturing',
+  text: 'Manufacturing'
+}, {
+  value: 'Manufacturing (Double Award)',
+  text: 'Manufacturing (Double Award)'
+}, {
+  value: 'Mathematics',
+  text: 'Mathematics'
+}, {
+  value: 'Mathematics (Modular)',
+  text: 'Mathematics (Modular)'
+}, {
+  value: 'Mathematics (Pilot)',
+  text: 'Mathematics (Pilot)'
+}, {
+  value: 'Mathematics (Linear)',
+  text: 'Mathematics (Linear)'
+}, {
+  value: 'Mathematics (Numeracy)',
+  text: 'Mathematics (Numeracy)'
+}, {
+  value: 'Mathematics A',
+  text: 'Mathematics A'
+}, {
+  value: 'Mathematics A (Linear)',
+  text: 'Mathematics A (Linear)'
+}, {
+  value: 'Mathematics B',
+  text: 'Mathematics B'
+}, {
+  value: 'Mathematics B (Modular)',
+  text: 'Mathematics B (Modular)'
+}, {
+  value: 'Mathematics C',
+  text: 'Mathematics C'
+}, {
+  value: 'Mathematics D (Pilot)',
+  text: 'Mathematics D (Pilot)'
+}, {
+  value: 'Media Studies',
+  text: 'Media Studies'
+}, {
+  value: 'Media Studies (Double Award)',
+  text: 'Media Studies (Double Award)'
+}, {
+  value: 'Methods in Mathematics',
+  text: 'Methods in Mathematics'
+}, {
+  value: 'Methods in Mathematics (Pilot)',
+  text: 'Methods in Mathematics (Pilot)'
+}, {
+  value: 'Modern Greek',
+  text: 'Modern Greek'
+}, {
+  value: 'Modern Hebrew',
+  text: 'Modern Hebrew'
+}, {
+  value: 'Modern Hebrew: Spoken Language (Short Course)',
+  text: 'Modern Hebrew: Spoken Language (Short Course)'
+}, {
+  value: 'Modern Hebrew: Written Language (Short Course)',
+  text: 'Modern Hebrew: Written Language (Short Course)'
+}, {
+  value: 'Motor Vehicle and Road User Studies',
+  text: 'Motor Vehicle and Road User Studies'
+}, {
+  value: 'Motor Vehicle and Road User Studies (NI)',
+  text: 'Motor Vehicle and Road User Studies (NI)'
+}, {
+  value: 'Moving Image Arts',
+  text: 'Moving Image Arts'
+}, {
+  value: 'Music',
+  text: 'Music'
+}, {
+  value: 'Panjabi',
+  text: 'Panjabi'
+}, {
+  value: 'Panjabi: Spoken Language (Short Course)',
+  text: 'Panjabi: Spoken Language (Short Course)'
+}, {
+  value: 'Panjabi: Written Language (Short Course)',
+  text: 'Panjabi: Written Language (Short Course)'
+}, {
+  value: 'Performing Arts',
+  text: 'Performing Arts'
+}, {
+  value: 'Performing Arts (Double Award)',
+  text: 'Performing Arts (Double Award)'
+}, {
+  value: 'Performing Arts: Dance',
+  text: 'Performing Arts: Dance'
+}, {
+  value: 'Persian',
+  text: 'Persian'
+}, {
+  value: 'Persian: Spoken Language (Short Course)',
+  text: 'Persian: Spoken Language (Short Course)'
+}, {
+  value: 'Persian: Written Language (Short Course)',
+  text: 'Persian: Written Language (Short Course)'
+}, {
+  value: 'Personal and Social Education (Short Course)',
+  text: 'Personal and Social Education (Short Course)'
+}, {
+  value: 'Personal and Social Education (Short Course) (Pilot)',
+  text: 'Personal and Social Education (Short Course) (Pilot)'
+}, {
+  value: 'Physical Education',
+  text: 'Physical Education'
+}, {
+  value: 'Physical Education (Double Award)',
+  text: 'Physical Education (Double Award)'
+}, {
+  value: 'Physical Education (Games)',
+  text: 'Physical Education (Games)'
+}, {
+  value: 'Physical Education (Short Course)',
+  text: 'Physical Education (Short Course)'
+}, {
+  value: 'Physical Education (Short Course) (Games)',
+  text: 'Physical Education (Short Course) (Games)'
+}, {
+  value: 'Physical Education A',
+  text: 'Physical Education A'
+}, {
+  value: 'Physical Education A (Short Course)',
+  text: 'Physical Education A (Short Course)'
+}, {
+  value: 'Physical Education B',
+  text: 'Physical Education B'
+}, {
+  value: 'Physical Education B (Short Course)',
+  text: 'Physical Education B (Short Course)'
+}, {
+  value: 'Physics',
+  text: 'Physics'
+}, {
+  value: 'Physics (Modular)',
+  text: 'Physics (Modular)'
+}, {
+  value: 'Physics A',
+  text: 'Physics A'
+}, {
+  value: 'Physics A (Gateway Science)',
+  text: 'Physics A (Gateway Science)'
+}, {
+  value: 'Physics B',
+  text: 'Physics B'
+}, {
+  value: 'Physics B (Twenty First Century Science)',
+  text: 'Physics B (Twenty First Century Science)'
+}, {
+  value: 'Physics M (Modular)',
+  text: 'Physics M (Modular)'
+}, {
+  value: 'Polish',
+  text: 'Polish'
+}, {
+  value: 'Polish: Spoken Language (Short Course)',
+  text: 'Polish: Spoken Language (Short Course)'
+}, {
+  value: 'Polish: Written Language (Short Course)',
+  text: 'Polish: Written Language (Short Course)'
+}, {
+  value: 'Portuguese',
+  text: 'Portuguese'
+}, {
+  value: 'Portuguese: Spoken Language (Short Course)',
+  text: 'Portuguese: Spoken Language (Short Course)'
+}, {
+  value: 'Portuguese: Written Language (Short Course)',
+  text: 'Portuguese: Written Language (Short Course)'
+}, {
+  value: 'Preparation for Working Life (Short Course)',
+  text: 'Preparation for Working Life (Short Course)'
+}, {
+  value: 'Preparation for Working Life (Short Course) (Pilot)',
+  text: 'Preparation for Working Life (Short Course) (Pilot)'
+}, {
+  value: 'Psychology',
+  text: 'Psychology'
+}, {
+  value: 'Psychology (Short Course)',
+  text: 'Psychology (Short Course)'
+}, {
+  value: 'Religious Studies',
+  text: 'Religious Studies'
+}, {
+  value: 'Religious Studies (Short Course)',
+  text: 'Religious Studies (Short Course)'
+}, {
+  value: 'Religious Studies A',
+  text: 'Religious Studies A'
+}, {
+  value: 'Religious Studies A (Short Course)',
+  text: 'Religious Studies A (Short Course)'
+}, {
+  value: 'Religious Studies B',
+  text: 'Religious Studies B'
+}, {
+  value: 'Religious Studies B (Short Course)',
+  text: 'Religious Studies B (Short Course)'
+}, {
+  value: 'Religious Studies C',
+  text: 'Religious Studies C'
+}, {
+  value: 'Religious Studies C (Pilot)',
+  text: 'Religious Studies C (Pilot)'
+}, {
+  value: 'Religious Studies C (Short Course)',
+  text: 'Religious Studies C (Short Course)'
+}, {
+  value: 'Religious Studies C (Short Course) (Pilot)',
+  text: 'Religious Studies C (Short Course) (Pilot)'
+}, {
+  value: 'Rural and Agricultural Science',
+  text: 'Rural and Agricultural Science'
+}, {
+  value: 'Russian',
+  text: 'Russian'
+}, {
+  value: 'Russian: Spoken Language (Short Course)',
+  text: 'Russian: Spoken Language (Short Course)'
+}, {
+  value: 'Russian: Written Language (Short Course)',
+  text: 'Russian: Written Language (Short Course)'
+}, {
+  value: 'Science',
+  text: 'Science'
+}, {
+  value: 'Science (Pilot)',
+  text: 'Science (Pilot)'
+}, {
+  value: 'Science: Double Award',
+  text: 'Science: Double Award'
+}, {
+  value: 'Science: Double Award A',
+  text: 'Science: Double Award A'
+}, {
+  value: 'Science: Double Award B',
+  text: 'Science: Double Award B'
+}, {
+  value: 'Science: Double Award C',
+  text: 'Science: Double Award C'
+}, {
+  value: 'Science: Single Award',
+  text: 'Science: Single Award'
+}, {
+  value: 'Science: Single Award A',
+  text: 'Science: Single Award A'
+}, {
+  value: 'Science: Single Award B',
+  text: 'Science: Single Award B'
+}, {
+  value: 'Science: Single Award C',
+  text: 'Science: Single Award C'
+}, {
+  value: 'Science: Single Award D (Pilot)',
+  text: 'Science: Single Award D (Pilot)'
+}, {
+  value: 'Science A',
+  text: 'Science A'
+}, {
+  value: 'Science B',
+  text: 'Science B'
+}, {
+  value: 'Science B (Science in Context)',
+  text: 'Science B (Science in Context)'
+}, {
+  value: 'Science M (Modular)',
+  text: 'Science M (Modular)'
+}, {
+  value: 'Single Award Science',
+  text: 'Single Award Science'
+}, {
+  value: 'Social Science',
+  text: 'Social Science'
+}, {
+  value: 'Sociology',
+  text: 'Sociology'
+}, {
+  value: 'Sociology (Short Course)',
+  text: 'Sociology (Short Course)'
+}, {
+  value: 'Spanish',
+  text: 'Spanish'
+}, {
+  value: 'Spanish (Short Course)',
+  text: 'Spanish (Short Course)'
+}, {
+  value: 'Spanish: Spoken Language (Short Course)',
+  text: 'Spanish: Spoken Language (Short Course)'
+}, {
+  value: 'Spanish: Written Language (Short Course)',
+  text: 'Spanish: Written Language (Short Course)'
+}, {
+  value: 'Spanish A',
+  text: 'Spanish A'
+}, {
+  value: 'Spanish A (Short Course)',
+  text: 'Spanish A (Short Course)'
+}, {
+  value: 'Spanish B',
+  text: 'Spanish B'
+}, {
+  value: 'Statistics',
+  text: 'Statistics'
+}, {
+  value: 'Technology and Design',
+  text: 'Technology and Design'
+}, {
+  value: 'Travel and Tourism',
+  text: 'Travel and Tourism'
+}, {
+  value: 'Turkish',
+  text: 'Turkish'
+}, {
+  value: 'Turkish: Spoken Language (Short Course)',
+  text: 'Turkish: Spoken Language (Short Course)'
+}, {
+  value: 'Turkish: Written Language (Short Course)',
+  text: 'Turkish: Written Language (Short Course)'
+}, {
+  value: 'Urdu',
+  text: 'Urdu'
+}, {
+  value: 'Urdu: Spoken Language (Short Course)',
+  text: 'Urdu: Spoken Language (Short Course)'
+}, {
+  value: 'Urdu: Written Language (Short Course)',
+  text: 'Urdu: Written Language (Short Course)'
+}, {
+  value: 'Use of Mathematics (Pilot)',
+  text: 'Use of Mathematics (Pilot)'
+}, {
+  value: 'Welsh: First Language',
+  text: 'Welsh: First Language'
+}, {
+  value: 'Welsh: Second Language',
+  text: 'Welsh: Second Language'
+}, {
+  value: 'Welsh: Second Language (Short Course)',
+  text: 'Welsh: Second Language (Short Course)'
+}, {
+  value: 'Welsh Literature',
+  text: 'Welsh Literature'
+}]

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -16,7 +16,7 @@ module.exports = {
     address_lookup: (process.env.MVP !== 'true'),
     automatic_breaks: process.env.MVP !== 'true',
     international_address: process.env.MVP !== 'true',
-    international_qualifications: process.env.MVP !== 'true',
+    international_qualifications: false,
     nationality: process.env.MVP !== 'true',
     self_amend: process.env.MVP !== 'true',
     self_amend_contact_details: process.env.MVP !== 'true',

--- a/app/routes/application/other-qualifications.js
+++ b/app/routes/application/other-qualifications.js
@@ -16,7 +16,7 @@ module.exports = router => {
     res.render('application/other-qualifications/review')
   })
 
-  // Render details page
+  // Render type page
   router.get('/application/:applicationId/other-qualifications/:id', (req, res) => {
     const { id } = req.params
     const { referrer } = req.query
@@ -28,9 +28,28 @@ module.exports = router => {
   })
 
   router.post('/application/:applicationId/other-qualifications/:id', (req, res) => {
-    const next = req.session.data.next || 'review'
+    const { applicationId, id } = req.params
     const { referrer } = req.query
 
-    res.redirect(referrer || `/application/${req.params.applicationId}/other-qualifications/${next}`)
+    res.redirect(referrer || `/application/${applicationId}/other-qualifications/${id}/details`)
+  })
+
+  // Render details page
+  router.get('/application/:applicationId/other-qualifications/:id/details', (req, res) => {
+    const { id } = req.params
+    const { referrer } = req.query
+
+    res.render('application/other-qualifications/details', {
+      id,
+      referrer
+    })
+  })
+
+  router.post('/application/:applicationId/other-qualifications/:id/details', (req, res) => {
+    const next = req.session.data.next || 'review'
+    const { applicationId } = req.params
+    const { referrer } = req.query
+
+    res.redirect(referrer || `/application/${applicationId}/other-qualifications/${next}`)
   })
 }

--- a/app/views/_includes/item/other-qualification.njk
+++ b/app/views/_includes/item/other-qualification.njk
@@ -2,15 +2,30 @@
 {{ govukSummaryList({
   rows: [{
     key: {
-      text: "Qualification"
+      text: "Type of qualification"
     },
     value: {
-      text: (item.type + " " + item.subject if item.type) or "Not entered"
+      text: item.type or "Not entered"
     },
     actions: {
       classes: "govuk-!-padding-right-2",
       items: [{
         href: applicationPath + "/other-qualifications/" + item.id + "?referrer=" + referrer,
+        text: "Change",
+        visuallyHiddenText: "year"
+      }]
+    } if canAmend
+  }, {
+    key: {
+      text: "Subject"
+    },
+    value: {
+      text: item.subject or "Not entered"
+    },
+    actions: {
+      classes: "govuk-!-padding-right-2",
+      items: [{
+        href: applicationPath + "/other-qualifications/" + item.id + "/details?referrer=" + referrer,
         text: "Change",
         visuallyHiddenText: "year"
       }]
@@ -25,7 +40,7 @@
     actions: {
       classes: "govuk-!-padding-right-2",
       items: [{
-        href: applicationPath + "/other-qualifications/" + item.id + "?referrer=" + referrer,
+        href: applicationPath + "/other-qualifications/" + item.id + "/details?referrer=" + referrer,
         text: "Change",
         visuallyHiddenText: "year"
       }]
@@ -40,7 +55,7 @@
     actions: {
       classes: "govuk-!-padding-right-2",
       items: [{
-        href: applicationPath + "/other-qualifications/" + item.id + "?referrer=" + referrer,
+        href: applicationPath + "/other-qualifications/" + item.id + "/details?referrer=" + referrer,
         text: "Change",
         visuallyHiddenText: "year"
       }]
@@ -55,7 +70,7 @@
     actions: {
       classes: "govuk-!-padding-right-2",
       items: [{
-        href: applicationPath + "/other-qualifications/" + item.id + "?referrer=" + referrer,
+        href: applicationPath + "/other-qualifications/" + item.id + "/details?referrer=" + referrer,
         text: "Change",
         visuallyHiddenText: "grade"
       }]

--- a/app/views/_includes/review/other-qualifications.njk
+++ b/app/views/_includes/review/other-qualifications.njk
@@ -1,9 +1,10 @@
 {% set applicationPath = "/application/" + applicationId %}
 {% set qualifications = applicationValue(["other-qualifications"]) %}
+{% set qualifications = qualifications | toArray | selectattr("id") %}
 
 {% if qualifications.length %}
-  {% set qualifications = qualifications | toArray | selectattr("id") %}
   {% for item in qualifications %}
+
     {% set qualificationHtml %}
       {% include "_includes/item/other-qualification.njk" %}
     {% endset %}

--- a/app/views/application/other-qualifications/details.njk
+++ b/app/views/application/other-qualifications/details.njk
@@ -51,7 +51,8 @@
     * not referred from a review page (which has an ‘Add another…’ button)
     * feature flag enabled
   #}
-  {% if action != "edit" and not referrer and data.flags.add_another %}
+  {% if action != "edit" and not referrer %}
+    <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
     {{ govukRadios({
       name: "next",
       fieldset: {
@@ -62,10 +63,10 @@
       },
       items: [{
         value: "add",
-        text: "Yes"
+        text: "Yes, I want to add another qualification"
       }, {
         value: "review",
-        text: "No"
+        text: "No, I’ve completed my other qualifications"
       }]
     }) }}
   {% endif %}

--- a/app/views/application/other-qualifications/details.njk
+++ b/app/views/application/other-qualifications/details.njk
@@ -1,0 +1,86 @@
+{% extends "_form.njk" %}
+
+{% set applicationPath = "/application/" + applicationId %}
+{% set title = "Qualification details" %}
+
+{% block pageNavigation %}
+  {% if referrer %}
+    {{ govukBackLink({
+      href: referrer
+    }) }}
+  {% else %}
+    {{ govukBackLink({
+      href: "/application/" + applicationId + "/other-qualifications/" + id
+    }) }}
+  {% endif %}
+{% endblock %}
+
+{% block primary %}
+  {{ govukInput({
+    label: {
+      text: "Subject",
+      classes: "govuk-label--m"
+    }
+  } | decorateApplicationAttributes(["other-qualifications", id, "subject"])) }}
+
+  {{ govukInput({
+    label: {
+      text: "Grade",
+      classes: "govuk-label--m"
+    },
+    classes: "govuk-input--width-10"
+  } | decorateApplicationAttributes(["other-qualifications", id, "grade"])) }}
+
+  {{ govukInput({
+    label: {
+      text: "Year qualification was awarded",
+      classes: "govuk-label--m"
+    },
+    classes: "govuk-input--width-4"
+  } | decorateApplicationAttributes(["other-qualifications", id, "year"])) }}
+
+  {{ govukInput({
+    label: {
+      text: "Institution where you studied",
+      classes: "govuk-label--m"
+    }
+  } | decorateApplicationAttributes(["other-qualifications", id, "org"])) }}
+
+  {# Only ask if want to add another if:
+    * not editing an existing item
+    * not referred from a review page (which has an ‘Add another…’ button)
+    * feature flag enabled
+  #}
+  {% if action != "edit" and not referrer and data.flags.add_another %}
+    {{ govukRadios({
+      name: "next",
+      fieldset: {
+        legend: {
+          text: "Do you want to add another qualification?",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      items: [{
+        value: "add",
+        text: "Yes"
+      }, {
+        value: "review",
+        text: "No"
+      }]
+    }) }}
+  {% endif %}
+
+  {{ govukButton({
+    text: "Save and continue"
+  }) }}
+{% endblock %}
+
+{% block pageScripts %}
+  <script src="/public/javascripts/autocomplete.min.js"></script>
+  <script>
+    accessibleAutocomplete.enhanceSelectElement({
+      defaultValue: '{{ valueOrPreviousQualificationValue(["other-qualifications", id, "country"]) }}',
+      selectElement: document.querySelector('#other-qualifications-{{ id }}-country')
+    })
+  </script>
+{% endblock %}

--- a/app/views/application/other-qualifications/details.njk
+++ b/app/views/application/other-qualifications/details.njk
@@ -16,12 +16,22 @@
 {% endblock %}
 
 {% block primary %}
-  {{ govukInput({
-    label: {
-      text: "Subject",
-      classes: "govuk-label--m"
-    }
-  } | decorateApplicationAttributes(["other-qualifications", id, "subject"])) }}
+  {% if applicationValue(["other-qualifications", id, "type"]) == "gcse" %}
+    {{ appAutocomplete({
+      label: {
+        text: "Subject",
+        classes: "govuk-label--m"
+      },
+      items: gcseSubjects
+    } | decorateApplicationAttributes(["other-qualifications", id, "subject"])) }}
+  {% else %}
+    {{ govukInput({
+      label: {
+        text: "Subject",
+        classes: "govuk-label--m"
+      }
+    } | decorateApplicationAttributes(["other-qualifications", id, "subject"])) }}
+  {% endif %}
 
   {{ govukInput({
     label: {
@@ -80,8 +90,8 @@
   <script src="/public/javascripts/autocomplete.min.js"></script>
   <script>
     accessibleAutocomplete.enhanceSelectElement({
-      defaultValue: '{{ valueOrPreviousQualificationValue(["other-qualifications", id, "country"]) }}',
-      selectElement: document.querySelector('#other-qualifications-{{ id }}-country')
+      defaultValue: '{{ valueOrPreviousQualificationValue(["other-qualifications", id, "subject"]) }}',
+      selectElement: document.querySelector('#other-qualifications-{{ id }}-subject')
     })
   </script>
 {% endblock %}

--- a/app/views/application/other-qualifications/index.njk
+++ b/app/views/application/other-qualifications/index.njk
@@ -1,7 +1,7 @@
 {% extends "_form.njk" %}
 
 {% set applicationPath = "/application/" + applicationId %}
-{% set title = "Other relevant qualifications" %}
+{% set title = "Academic and other relevant qualifications" %}
 
 {% block pageNavigation %}
   {% if referrer %}
@@ -17,32 +17,59 @@
 {% endblock %}
 
 {% block primary %}
-  <p class="govuk-body">Enter your other qualifications as completely as you can, including all your GCSEs, A levels, and undergraduate and postgraduate degrees.</p>
-  <p class="govuk-body">You should also tell us about your vocational, practical and creative qualifications.</p>
+  {% set otherUkConditionalHtml %}
+    {{ govukInput({
+      label: {
+        text: "Enter type of qualification"
+      }
+    } | decorateApplicationAttributes(["other-qualifications", id, "type-uk"])) }}
+  {% endset %}
 
-  {{ govukInput({
-    label: {
-      text: "Type of qualification",
-      classes: "govuk-label--m"
+  {% set nonUkConditionalHtml %}
+    {{ govukInput({
+      label: {
+        text: "Enter type of qualification"
+      }
+    } | decorateApplicationAttributes(["other-qualifications", id, "type-non-uk"])) }}
+    {{ appAutocomplete({
+      label: {
+        text: "In which country did you gain this qualification?"
+      },
+      items: countries
+    } | decorateApplicationAttributes(["other-qualifications", id, "country"])) }}
+  {% endset %}
+
+  <p class="govuk-body">Enter your qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.</p>
+  <p class="govuk-body">Undergraduate and postgraduate degrees should be included in the ‘Degree’ section.</p>
+
+  {{ govukRadios({
+    fieldset: {
+      legend: {
+        text: "Type of qualification",
+        classes: "govuk-label--m"
+      },
+      attributes: {
+        "data-module": "clear-hidden"
+      }
     },
-    hint: {
-      text: "For example, GCSE, A level, BTEC, NVQ or non-UK other, please specify"
-    }
+    items: [{
+      text: "GCSE"
+    }, {
+      text: "AS level"
+    }, {
+      text: "A level"
+    }, {
+      text: "Other UK qualification",
+      conditional: {
+        html: otherUkConditionalHtml
+      }
+    }, {
+      text: "Non-UK qualification",
+      conditional: {
+        html: nonUkConditionalHtml
+      }
+    } if data.flags.international_qualifications]
   } | decorateApplicationAttributes(["other-qualifications", id, "type"])) }}
-
-  {{ govukInput({
-    label: {
-      text: "Subject",
-      classes: "govuk-label--m"
-    }
-  } | decorateApplicationAttributes(["other-qualifications", id, "subject"])) }}
-
-  {{ govukInput({
-    label: {
-      text: "Institution where you studied",
-      classes: "govuk-label--m"
-    }
-  } | decorateApplicationAttributes(["other-qualifications", id, "org"])) }}
 
   {% set internationalConditionalHtml %}
     {{ appAutocomplete({
@@ -52,40 +79,6 @@
       items: countries
     } | decorateApplicationAttributes(["other-qualifications", id, "country"])) }}
   {% endset %}
-
-  {{ govukRadios({
-    fieldset: {
-      legend: {
-        text: "This institution is based:"
-      }
-    },
-    items: [{
-      value: "domestic",
-      text: "In the UK"
-    }, {
-      value: "international",
-      text: "Outside the UK",
-      conditional: {
-        html: internationalConditionalHtml
-      }
-    }]
-  } | decorateApplicationAttributes(["other-qualifications", id, "provenance"])) }}
-
-  {{ govukInput({
-    label: {
-      text: "Grade",
-      classes: "govuk-label--m"
-    },
-    classes: "govuk-input--width-10"
-  } | decorateApplicationAttributes(["other-qualifications", id, "grade"])) }}
-
-  {{ govukInput({
-    label: {
-      text: "Year qualification was awarded",
-      classes: "govuk-label--m"
-    },
-    classes: "govuk-input--width-4"
-  } | decorateApplicationAttributes(["other-qualifications", id, "year"])) }}
 
   {# Only ask if want to add another if:
     * not editing an existing item

--- a/app/views/application/other-qualifications/index.njk
+++ b/app/views/application/other-qualifications/index.njk
@@ -20,7 +20,7 @@
   {% set otherUkConditionalHtml %}
     {{ govukInput({
       label: {
-        text: "Enter type of qualification"
+        text: "Type of qualification"
       }
     } | decorateApplicationAttributes(["other-qualifications", id, "type-uk"])) }}
   {% endset %}
@@ -28,7 +28,7 @@
   {% set nonUkConditionalHtml %}
     {{ govukInput({
       label: {
-        text: "Enter type of qualification"
+        text: "Type of qualification"
       }
     } | decorateApplicationAttributes(["other-qualifications", id, "type-non-uk"])) }}
     {{ appAutocomplete({
@@ -53,17 +53,22 @@
       }
     },
     items: [{
+      value: "gcse",
       text: "GCSE"
     }, {
+      value: "as-level",
       text: "AS level"
     }, {
+      value: "a-level",
       text: "A level"
     }, {
-      text: "Other UK qualification",
+      value: "other-uk",
+      text: "Other UK qualification" if data.flags.international_qualifications else "Other",
       conditional: {
         html: otherUkConditionalHtml
       }
     }, {
+      value: "non-uk",
       text: "Non-UK qualification",
       conditional: {
         html: nonUkConditionalHtml
@@ -105,7 +110,7 @@
   {% endif %}
 
   {{ govukButton({
-    text: "Save and continue"
+    text: "Continue"
   }) }}
 {% endblock %}
 

--- a/app/views/application/other-qualifications/review.njk
+++ b/app/views/application/other-qualifications/review.njk
@@ -2,7 +2,7 @@
 
 {% set applicationPath = "/application/" + applicationId %}
 {% set formaction = applicationPath %}
-{% set title = "Other relevant qualifications" %}
+{% set title = "Academic and other relevant qualifications" %}
 {% set referrer = applicationPath + "/other-qualifications/review" %}
 {% set canAmend = true %}
 
@@ -17,7 +17,7 @@
   {% include "_includes/review/other-qualifications.njk" %}
   {{ govukButton({
     text: "Add another qualification",
-    href: applicationPath + "/other-qualifications/add?referrer=" + referrer,
+    href: applicationPath + "/other-qualifications/add",
     classes: "govuk-button--secondary"
   }) }}
 

--- a/server.js
+++ b/server.js
@@ -121,6 +121,7 @@ app.locals.extensionConfig = extensions.getAppConfig()
 app.locals.countries = require('./app/data/countries')
 app.locals.nationalities = require('./app/data/nationalities')
 app.locals.providers = require('./app/data/providers')
+app.locals.gcseSubjects = require('./app/data/gcse-subjects')
 
 // Session uses service name to avoid clashes with other prototypes
 const sessionName = 'govuk-prototype-kit-' + (Buffer.from(config.serviceName, 'utf8')).toString('hex')


### PR DESCRIPTION
First pass at prompting for a qualification type (GCSE, A Level, AS Level, Other) within the other qualifications section.

Also includes support for entering structured subjects for GCSE qualifications. This aspect may need more work (ie do we show pilot qualifications, do we merge qualifications with similar subject titles, etc). These issues can be addressed later, in a separate PR.

<img width="770" alt="other-qualification-types" src="https://user-images.githubusercontent.com/813383/76624367-0c266d00-652d-11ea-8f34-db5c605c1688.png">
