### PR TITLE
Additional guidance for GCSE grades

### DIFF
--- a/app/views/_includes/item/gcse.njk
+++ b/app/views/_includes/item/gcse.njk
@@ -23,7 +23,7 @@
     },
     actions: {
       items: [{
-        href: applicationPath + "/gcse/" + item.id + "?referrer=" + referrer,
+        href: applicationPath + "/gcse/" + id + "?referrer=" + referrer,
         text: "Change",
         visuallyHiddenText: "year"
       }]
@@ -37,7 +37,7 @@
     },
     actions: {
       items: [{
-        href: applicationPath + "/gcse/" + item.id + "?referrer=" + referrer,
+        href: applicationPath + "/gcse/" + id + "?referrer=" + referrer,
         text: "Change",
         visuallyHiddenText: "year"
       }]
@@ -51,7 +51,7 @@
     },
     actions: {
       items: [{
-        href: applicationPath + "/gcse/" + item.id + "/year?referrer=" + referrer,
+        href: applicationPath + "/gcse/" + id + "/year?referrer=" + referrer,
         text: "Change",
         visuallyHiddenText: "year"
       }]
@@ -65,7 +65,7 @@
     },
     actions: {
       items: [{
-        href: applicationPath + "/gcse/" + item.id + "/grade?referrer=" + referrer,
+        href: applicationPath + "/gcse/" + id + "/grade?referrer=" + referrer,
         text: "Change",
         visuallyHiddenText: "grade"
       }]

--- a/app/views/application/gcse/grade.njk
+++ b/app/views/application/gcse/grade.njk
@@ -3,24 +3,27 @@
 {% set subject = (id | capitalize) if id == "english" else id %}
 {% set title = "What grade is your " + subject + " qualification?" %}
 
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: paths.back
+  }) }}
+{% endblock %}
+
+{% block primary %}
 {% if applicationValue(["gcse", id, "type"]) == "GCSE" %}
   {# Available grades: U,1,2,3,4,5,6,7,8,9 or U,G,F,E,D,C,C*,B,A,A* #}
   {% if id == "science" %}
     {# Maximum number of grades: 3 #}
-    {% set guidance %}
-      <p class="govuk-body">Providers expect you to have a grade C or 4 (or the equivalent) in order to train. If you don't have this, contact your provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
-      <p class="govuk-body">If you have a combined or triple GCSE in science, enter your total grade.</p>
-    {% endset %}
+    <p class="govuk-body">Providers expect you to have a grade C or 4 (or the equivalent) in order to train. If you don't have this, contact your provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
+    <p class="govuk-body">If you have a combined or triple GCSE in science, enter your total grade.</p>
     {% set hintText = "For example: ‘A*A*A’, ‘AB’, ‘B’, ‘998’, ‘88’, ‘7’" %}
   {% elif id == "english" %}
-    {% set guidance %}
-      <p class="govuk-body">Providers expect you to have a grade C or 4 (or the equivalent) in order to train. If you don't have this, contact your chosen provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
-      <p class="govuk-body">If you have a GCSE in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.</p>
-      {{ govukDetails({
-        summaryText: "If you have more than one English qualification",
-        text: "Enter any English Literature qualifications under 'Academic and other relevant qualifications'"
-      }) }}
-    {% endset %}
+    <p class="govuk-body">Providers expect you to have a grade C or 4 (or the equivalent) in order to train. If you don't have this, contact your chosen provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
+    <p class="govuk-body">If you have a GCSE in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.</p>
+    {{ govukDetails({
+      summaryText: "If you have more than one English qualification",
+      text: "Enter any English Literature qualifications under 'Academic and other relevant qualifications'"
+    }) }}
     {% set hintText = "For example, ‘C’ or ‘4’" %}
   {% else %}
     {# Maximum number of grades: 1 #}
@@ -31,15 +34,15 @@
   {# Available grades: U,E,D,C,B,A #}
   {% if id == "science" %}
     {# Maximum number of grades: 3 #}
-    {% set guidance %}
-      <p class="govuk-body">If you have a combined or triple GCSE in science, enter your total grade.</p>
-    {% endset %}
+    <p class="govuk-body">If you have a combined or triple GCSE in science, enter your total grade.</p>
     {% set hintText = "For example, ‘ABC’, ‘AA’, ‘B’" %}
   {% elif id == "english" %}
-    {% set guidance %}
-      <p class="govuk-body">Enter your grade for English Language O level. Providers expect you to have a grade C (or the equivalent) in order to train. If you don't have this, contact your chosen provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
-      <p class="govuk-body">If you have an O level in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.</p>
-    {% endset %}
+    <p class="govuk-body">Enter your grade for English Language O level. Providers expect you to have a grade C (or the equivalent) in order to train. If you don't have this, contact your chosen provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
+    <p class="govuk-body">If you have an O level in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.</p>
+    {{ govukDetails({
+      summaryText: "If you have more than one English qualification",
+      text: "Enter any English Literature qualifications under 'Academic and other relevant qualifications'"
+    }) }}
     {% set hintText = "For example, ‘C’" %}
   {% else %}
     {# Maximum number of grades: 1 #}
@@ -50,24 +53,13 @@
   {# Available grades: 7,6,5,4,3,2,1 or D,B,C,A #}
   {% if id == "science" %}
     {# Maximum number of grades: 1 or 3 #}
-    {% set guidance %}
-      <p class="govuk-body">If you studied three science subjects separately or took a general science qualification, enter your total grade.</p>
-    {% endset %}
+    <p class="govuk-body">If you studied three science subjects separately or took a general science qualification, enter your total grade.</p>
     {% set hintText = "For example, ‘A*A*A*’, ‘ABC’, ‘A’, ‘777’, ‘654’, ‘6’" %}
   {% else %}
     {# Maximum number of grades: 1 #}
     {% set hintText = "For example, ‘C’ or ‘4’" %}
   {% endif %}
 {% endif %}
-
-{% block pageNavigation %}
-  {{ govukBackLink({
-    href: paths.back
-  }) }}
-{% endblock %}
-
-{% block primary %}
-  {{ guidance | safe }}
 
   {{ govukInput({
     label: {

--- a/app/views/application/gcse/grade.njk
+++ b/app/views/application/gcse/grade.njk
@@ -10,16 +10,16 @@
 {% endblock %}
 
 {% block primary %}
+<p class="govuk-body">Providers expect you to have a grade C or 4 (or the equivalent) in order to train. If you don't have this, contact your provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
 {% if applicationValue(["gcse", id, "type"]) == "GCSE" %}
   {# Available grades: U,1,2,3,4,5,6,7,8,9 or U,G,F,E,D,C,C*,B,A,A* #}
   {% if id == "science" %}
     {# Maximum number of grades: 3 #}
-    <p class="govuk-body">Providers expect you to have a grade C or 4 (or the equivalent) in order to train. If you don't have this, contact your provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
     <p class="govuk-body">If you have a combined or triple GCSE in science, enter your total grade.</p>
     {% set hintText = "For example: ‘A*A*A’, ‘AB’, ‘B’, ‘998’, ‘88’, ‘7’" %}
   {% elif id == "english" %}
     <p class="govuk-body">Providers expect you to have a grade C or 4 (or the equivalent) in order to train. If you don't have this, contact your chosen provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
-    <p class="govuk-body">If you have a GCSE in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.</p>
+    <p class="govuk-body">If you have a GCSE in English Literature only, enter this grade here – but be aware that providers may want further evidence of your abilities in English.</p>
     {{ govukDetails({
       summaryText: "If you have more than one English qualification",
       text: "Enter any English Literature qualifications under 'Academic and other relevant qualifications'"
@@ -38,7 +38,7 @@
     {% set hintText = "For example, ‘ABC’, ‘AA’, ‘B’" %}
   {% elif id == "english" %}
     <p class="govuk-body">Enter your grade for English Language O level. Providers expect you to have a grade C (or the equivalent) in order to train. If you don't have this, contact your chosen provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
-    <p class="govuk-body">If you have an O level in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.</p>
+    <p class="govuk-body">If you have an O level in English Literature only, enter this grade here – but be aware that providers may want further evidence of your abilities in English.</p>
     {{ govukDetails({
       summaryText: "If you have more than one English qualification",
       text: "Enter any English Literature qualifications under 'Academic and other relevant qualifications'"

--- a/app/views/application/gcse/grade.njk
+++ b/app/views/application/gcse/grade.njk
@@ -1,7 +1,12 @@
 {% extends "_form.njk" %}
 
 {% set subject = (id | capitalize) if id == "english" else id %}
-{% set title = "What grade is your " + subject + " qualification?" %}
+{% set type = applicationValue(["gcse", id, "type"]) %}
+{% if type == "Other UK qualification" or type == "Scottish National 5"  %}
+  {% set title = "What grade is your " + subject + " qualification?" %}
+{% else %}
+  {% set title = "What grade is your " + subject + " " + type + "?" %}
+{% endif %}
 
 {% block pageNavigation %}
   {{ govukBackLink({

--- a/app/views/application/gcse/grade.njk
+++ b/app/views/application/gcse/grade.njk
@@ -8,13 +8,18 @@
   {% if id == "science" %}
     {# Maximum number of grades: 3 #}
     {% set guidance %}
-      <p class="govuk-body">If you have a single, double (also known as combined) or triple GCSE in science, enter your total grade.</p>
+      <p class="govuk-body">Providers expect you to have a grade C or 4 (or the equivalent) in order to train. If you don't have this, contact your provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
+      <p class="govuk-body">If you have a combined or triple GCSE in science, enter your total grade.</p>
     {% endset %}
-    {% set hintText = "For example: ‘A*A*A*’, ‘AA’, ‘B’, ‘999’, ‘88’, ‘7’" %}
+    {% set hintText = "For example: ‘A*A*A’, ‘AB’, ‘B’, ‘998’, ‘88’, ‘7’" %}
   {% elif id == "english" %}
     {% set guidance %}
-      <p class="govuk-body">Enter your grade for English Language GCSE.</p>
+      <p class="govuk-body">Providers expect you to have a grade C or 4 (or the equivalent) in order to train. If you don't have this, contact your chosen provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
       <p class="govuk-body">If you have a GCSE in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.</p>
+      {{ govukDetails({
+        summaryText: "If you have more than one English qualification",
+        text: "Enter any English Literature qualifications under 'Academic and other relevant qualifications'"
+      }) }}
     {% endset %}
     {% set hintText = "For example, ‘C’ or ‘4’" %}
   {% else %}
@@ -27,12 +32,12 @@
   {% if id == "science" %}
     {# Maximum number of grades: 3 #}
     {% set guidance %}
-      <p class="govuk-body">If you have a single, double or triple O Level in science, enter your total grade.</p>
+      <p class="govuk-body">If you have a combined or triple GCSE in science, enter your total grade.</p>
     {% endset %}
     {% set hintText = "For example, ‘ABC’, ‘AA’, ‘B’" %}
   {% elif id == "english" %}
     {% set guidance %}
-      <p class="govuk-body">Enter your grade for English Language O level.</p>
+      <p class="govuk-body">Enter your grade for English Language O level. Providers expect you to have a grade C (or the equivalent) in order to train. If you don't have this, contact your chosen provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
       <p class="govuk-body">If you have an O level in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.</p>
     {% endset %}
     {% set hintText = "For example, ‘C’" %}

--- a/app/views/application/gcse/grade.njk
+++ b/app/views/application/gcse/grade.njk
@@ -18,11 +18,14 @@
     <p class="govuk-body">If you have a combined or triple GCSE in science, enter your total grade.</p>
     {% set hintText = "For example: ‘A*A*A’, ‘AB’, ‘B’, ‘998’, ‘88’, ‘7’" %}
   {% elif id == "english" %}
-    <p class="govuk-body">Providers expect you to have a grade C or 4 (or the equivalent) in order to train. If you don't have this, contact your chosen provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
-    <p class="govuk-body">If you have a GCSE in English Literature only, enter this grade here – but be aware that providers may want further evidence of your abilities in English.</p>
+    {{ govukDetails({
+      classes: "govuk-!-margin-bottom-2",
+      summaryText: "If you have a GCSE in English Literature only",
+      text: "Enter your grade here – but be aware that providers may want further evidence of your abilities in English."
+    }) }}
     {{ govukDetails({
       summaryText: "If you have more than one English qualification",
-      text: "Enter any English Literature qualifications under 'Academic and other relevant qualifications'"
+      text: "Enter any English Literature qualifications under ‘Academic and other relevant qualifications’"
     }) }}
     {% set hintText = "For example, ‘C’ or ‘4’" %}
   {% else %}
@@ -37,8 +40,11 @@
     <p class="govuk-body">If you have a combined or triple GCSE in science, enter your total grade.</p>
     {% set hintText = "For example, ‘ABC’, ‘AA’, ‘B’" %}
   {% elif id == "english" %}
-    <p class="govuk-body">Enter your grade for English Language O level. Providers expect you to have a grade C (or the equivalent) in order to train. If you don't have this, contact your chosen provider to discuss your options. You might be able to retake an exam or do an equivalence test.</p>
-    <p class="govuk-body">If you have an O level in English Literature only, enter this grade here – but be aware that providers may want further evidence of your abilities in English.</p>
+    {{ govukDetails({
+      classes: "govuk-!-margin-bottom-2",
+      summaryText: "If you have an O level in English Literature only",
+      text: "Enter your grade here – but be aware that providers may want further evidence of your abilities in English."
+    }) }}
     {{ govukDetails({
       summaryText: "If you have more than one English qualification",
       text: "Enter any English Literature qualifications under 'Academic and other relevant qualifications'"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "npm run lint && gulp generate-assets && jest"
   },
   "dependencies": {
-    "acorn": "^7.1.0",
+    "acorn": "^7.1.1",
     "ansi-colors": "^4.0.0",
     "basic-auth": "^2.0.0",
     "basic-auth-connect": "^1.0.0",
@@ -30,16 +30,16 @@
     "express-session": "^1.17.0",
     "express-writer": "^0.0.4",
     "fancy-log": "^1.3.3",
-    "govuk-frontend": "^3.5.0",
+    "govuk-frontend": "^3.6.0",
     "gulp": "^4.0.2",
-    "gulp-nodemon": "^2.1.0",
+    "gulp-nodemon": "^2.5.0",
     "gulp-sass": "^4.0.1",
     "gulp-sourcemaps": "^2.6.0",
-    "humanize-duration": "^3.21.0",
+    "humanize-duration": "^3.22.0",
     "keypather": "^3.0.0",
     "luxon": "^1.22.0",
     "marked": "^0.8.0",
-    "mongoose": "^5.9.2",
+    "mongoose": "^5.9.4",
     "notifications-node-client": "^4.7.2",
     "nunjucks": "^3.1.3",
     "portscanner": "^2.1.1",
@@ -48,7 +48,7 @@
     "require-dir": "^1.0.0",
     "sync-request": "^6.1.0",
     "universal-analytics": "^0.4.16",
-    "uuid": "^7.0.1"
+    "uuid": "^7.0.2"
   },
   "greenkeeper": {
     "ignore": [


### PR DESCRIPTION
## Minimum qualification grade

For GCSE or equivalent grades, include guidance around minimum grade and suggestion to contact a provider if currently don‘t meet the criteria.

<img width="690" alt="Screenshot 2020-03-11 at 11 39 05" src="https://user-images.githubusercontent.com/813383/76413241-fe39e600-638c-11ea-91fb-a72d00de11f2.png">

* * *

## Multiple English qualifications

For English GCSE subject, add two disclosures:
1. Only have an English Literature qualification
2. Have more than one English qualification 

<img width="720" alt="Screenshot 2020-03-11 at 11 38 50" src="https://user-images.githubusercontent.com/813383/76413239-fda14f80-638c-11ea-82dd-e1ba5a632e8b.png">

