### PR TITLE
Allow creation of Apply 2 applications

### DIFF
--- a/app/data/dummy-application.js
+++ b/app/data/dummy-application.js
@@ -1,6 +1,7 @@
 module.exports = {
   status: 'started',
   welcomeFlow: false,
+  apply2: false,
   choices: {
     ABCDE: {
       courseCode: '2XT2',

--- a/app/data/dummy-application.js
+++ b/app/data/dummy-application.js
@@ -59,6 +59,10 @@ module.exports = {
     disclose: 'true',
     statement: 'I currently require the use of a wheelchair.'
   },
+  suitability: {
+    disclose: 'true',
+    statement: 'I have a criminal record in Spain'
+  },
   degree: {
     kq19m: {
       id: 'kq19m',

--- a/app/data/dummy-apply-2-application.js
+++ b/app/data/dummy-apply-2-application.js
@@ -1,0 +1,14 @@
+// Copies dummy application and tweaks some fields
+var dummyApply2Application = JSON.parse(JSON.stringify(require('./dummy-application')))
+
+// Custom Apply 2 fields
+dummyApply2Application.apply2 = true
+dummyApply2Application.previousApplications = ['12345']
+
+// No sections completed
+dummyApply2Application.completed = {}
+
+// No choices yet
+dummyApply2Application.choices = {}
+
+module.exports = dummyApply2Application

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -1,7 +1,9 @@
 const dummyApplication = require('./dummy-application')
+const dummyApply2Application = require('./dummy-apply-2-application')
 
 const testData = {
-  12345: dummyApplication
+  12345: dummyApplication,
+  ABCDE: dummyApply2Application
 }
 
 module.exports = {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -15,6 +15,7 @@ function createNewApplication (req) {
       candidate: {},
       'contact-details': {},
       'reasonable-adjustments': {},
+      suitability: {},
       degree: {},
       'other-qualifications': {},
       gcse: {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -171,6 +171,7 @@ module.exports = router => {
     apply2Application.apply2 = true
     apply2Application.choices = {}
     apply2Application.completed = {}
+    apply2Application.previousApplications = [existingApplicationId]
 
     data.applications[code] = apply2Application
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -159,6 +159,24 @@ module.exports = router => {
     res.render('application/index')
   })
 
+  // Generate apply2 application from an existing one
+  router.get('/application/:applicationId/apply2', (req, res) => {
+    const code = utils.generateRandomString()
+    const data = req.session.data
+    const existingApplicationId = req.params.applicationId
+    const existingApplication = data.applications[existingApplicationId]
+    const apply2Application = JSON.parse(JSON.stringify(existingApplication))
+
+    apply2Application.welcomeFlow = false
+    apply2Application.apply2 = true
+    apply2Application.choices = {}
+    apply2Application.completed = {}
+
+    data.applications[code] = apply2Application
+
+    res.redirect(`/application/${code}`)
+  })
+
   // Render submitted page
   router.all('/application/:applicationId/submitted', (req, res) => {
     const { phase } = req.query

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -11,6 +11,7 @@ function createNewApplication (req) {
   if (typeof data.applications[code] === 'undefined') {
     data.applications[code] = {
       status: 'started',
+      apply2: false,
       choices: {},
       candidate: {},
       'contact-details': {},


### PR DESCRIPTION
- Include an "apply2" boolean for each application, which we can use to toggle Apply2 specific features (eg limit that application to 1 course choice)
- Create an apply2 dummy application derived from the existing dummy
- Add a route for copying an existing application and making it into a new Apply 2 one
- Add missing suitability fields to defaults and dummy applications