### PR TITLE
First pass at tweaks to the application for Apply 2

### DIFF
--- a/app/data/dummy-apply-2-application.js
+++ b/app/data/dummy-apply-2-application.js
@@ -11,4 +11,8 @@ dummyApply2Application.completed = {}
 // No choices yet
 dummyApply2Application.choices = {}
 
+// References received
+dummyApply2Application.referees.first.status = 'Received'
+dummyApply2Application.referees.second.status = 'Received'
+
 module.exports = dummyApply2Application

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -175,6 +175,14 @@ module.exports = router => {
     apply2Application.completed = {}
     apply2Application.previousApplications = [existingApplicationId]
 
+    if (apply2Application.referees && apply2Application.referees.first) {
+      apply2Application.referees.first.status = 'Received'
+    }
+
+    if (apply2Application.referees && apply2Application.referees.second) {
+      apply2Application.referees.second.status = 'Received'
+    }
+
     data.applications[code] = apply2Application
 
     res.redirect(`/application/${code}?copied=true`)

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -155,8 +155,10 @@ module.exports = router => {
 
   // Render application page
   router.all('/application/:applicationId', (req, res) => {
+    const showCopiedBanner = req.query.copied
+
     req.session.data.applications[req.params.applicationId].welcomeFlow = false
-    res.render('application/index')
+    res.render('application/index', { showCopiedBanner })
   })
 
   // Generate apply2 application from an existing one
@@ -175,7 +177,7 @@ module.exports = router => {
 
     data.applications[code] = apply2Application
 
-    res.redirect(`/application/${code}`)
+    res.redirect(`/application/${code}?copied=true`)
   })
 
   // Render submitted page

--- a/app/routes/application/choices.js
+++ b/app/routes/application/choices.js
@@ -132,7 +132,7 @@ module.exports = router => {
     const count = Object.keys(applicationData.choices).length
     const paths = pickPaths(req)
 
-    if (count === 3 || req.body['add-another-course'] === 'no') {
+    if (count === 3 || applicationData.apply2 || req.body['add-another-course'] === 'no') {
       res.redirect(req.params.referrer || paths.next)
     } else {
       res.render('application/choices/another', {

--- a/app/routes/application/review.js
+++ b/app/routes/application/review.js
@@ -12,7 +12,7 @@ module.exports = router => {
     if (successFlash[0] === 'submitted-incompleted-application') {
       pageObject.errorList = []
       const sections = {
-        choices: 'Course choices not marked as completed',
+        choices: applicationData.apply2 ? 'Course choice not marked as completed' : 'Course choices not marked as completed',
         candidate: 'Personal details not entered',
         'contact-details': 'Contact details not entered',
         'reasonable-adjustments': 'Training with a disability not entered',

--- a/app/views/_includes/item/reference.njk
+++ b/app/views/_includes/item/reference.njk
@@ -1,5 +1,10 @@
 {% set applicationPath = "/application/" + applicationId %}
 {% set status = item.status or "requested" %}
+
+{% if applicationValue('apply2') %}
+  {% set showReferenceStatus = true %}
+{% endif %}
+
 {% set statusHtml %}
   {{ govukTag({
     classes: "app-tag--" + status,

--- a/app/views/_includes/item/reference.njk
+++ b/app/views/_includes/item/reference.njk
@@ -3,6 +3,7 @@
 
 {% if applicationValue('apply2') %}
   {% set showReferenceStatus = true %}
+  {% set canAmend = false %}
 {% endif %}
 
 {% set statusHtml %}

--- a/app/views/_includes/need-help.njk
+++ b/app/views/_includes/need-help.njk
@@ -1,4 +1,11 @@
 {% set contentHtml %}
+  {% if applicationValue('apply2') %}
+    <p class="govuk-!-font-size-16">
+      <a href="#">View previous applications</a>
+    </p>
+
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="help-title">Need help?</h2>
+  {% endif %}
   <ul class="govuk-list govuk-!-font-size-16">
     <li>Email: <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher<wbr>@digital.education.gov.uk</a></li>
     <li>Monday to Friday (except public holidays)</li>
@@ -8,7 +15,7 @@
 
 {{ appRelated({
   name: "help",
-  title: "Need help?",
+  title: "Previous applications" if applicationValue('apply2') else "Need help?",
   content: {
     html: contentHtml
   }

--- a/app/views/_includes/review/references.njk
+++ b/app/views/_includes/review/references.njk
@@ -6,8 +6,12 @@
       {% if not canAmend %}
         <p class="govuk-body">We’ve contacted the referees you provided below. We’ll let you know if they don’t give a reference.</p>
       {% else %}
-        {# You can’t change your referees once application has been submitted #}
-        <p class="govuk-body">We’ll contact your referees after you submit your application. We’ll let you know if they don’t give a reference.</p>
+        {% if applicationValue('apply2') %}
+          <p class="govuk-body">If you replace a referee we will contact them after you submit your application. We’ll let you know if they don’t give a reference.</p>
+        {% else %}
+          {# You can’t change your referees once application has been submitted #}
+          <p class="govuk-body">We’ll contact your referees after you submit your application. We’ll let you know if they don’t give a reference.</p>
+        {% endif %}
       {% endif %}
     </div>
   </div>

--- a/app/views/_includes/review/references.njk
+++ b/app/views/_includes/review/references.njk
@@ -1,12 +1,16 @@
 {% set complete = references | length > 0 %}
 {% if complete %}
   {% set canAmend = true if not hasSubmittedApplications() %}
-  {% if not canAmend %}
-    <p class="govuk-body">We’ve contacted the referees you provided below. We’ll let you know if they don’t give a reference.</p>
-  {% else %}
-    {# You can’t change your referees once application has been submitted #}
-    <p class="govuk-body">We’ll contact your referees after you submit your application. We’ll let you know if they don’t give a reference.</p>
-  {% endif %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if not canAmend %}
+        <p class="govuk-body">We’ve contacted the referees you provided below. We’ll let you know if they don’t give a reference.</p>
+      {% else %}
+        {# You can’t change your referees once application has been submitted #}
+        <p class="govuk-body">We’ll contact your referees after you submit your application. We’ll let you know if they don’t give a reference.</p>
+      {% endif %}
+    </div>
+  </div>
   {% set references = references | toArray %}
   {% for item in references %}
     {% set refereeHtml %}

--- a/app/views/application/apply-again.njk
+++ b/app/views/application/apply-again.njk
@@ -17,7 +17,8 @@
   <hr class="govuk-section-break govuk-section-break--m">
   {{ govukButton({
     classes: "govuk-!-margin-bottom-5",
-    text: "Make a new application",
+    isStartButton: true,
+    text: "Start now",
     href: "/application/" + applicationId + "/apply2"
   }) }}
   <p class="govuk-body">or</p>

--- a/app/views/application/apply-again.njk
+++ b/app/views/application/apply-again.njk
@@ -1,0 +1,25 @@
+{% extends "_content.njk" %}
+
+{% set title = "Do you want to apply again?" %}
+
+{% block primary %}
+  <p>Your first application was unsuccessful.</p>
+
+  <p>If you apply again we’ll:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>copy your application so you don’t need to start again</li>
+    <li>let you make changes to each section</li>
+    <li>keep your references so you won’t need to request new ones</li>
+  </ul>
+
+  <p>You can only apply to 1 course at a time at this stage of your application.</p>
+
+  <hr class="govuk-section-break govuk-section-break--m">
+  {{ govukButton({
+    classes: "govuk-!-margin-bottom-5",
+    text: "Make a new application",
+    href: "/application/" + applicationId + "/apply2"
+  }) }}
+  <p class="govuk-body">or</p>
+  <p class="govuk-body"><a href="/application/{{ applicationId }}">Go to your dashboard</a></p>
+{% endblock %}

--- a/app/views/application/choices/index.njk
+++ b/app/views/application/choices/index.njk
@@ -62,7 +62,7 @@
         }) }}
       {% endif %}
 
-      {% if choiceCount >= 1 and choiceCount < 3 %}
+      {% if choiceCount >= 1 and choiceCount < 3 and not applicationValue(["apply2"]) %}
         {{ govukButton({
           classes: "govuk-button--secondary govuk-!-margin-bottom-9",
           text: "Add another course",

--- a/app/views/application/choices/index.njk
+++ b/app/views/application/choices/index.njk
@@ -27,6 +27,12 @@
 {% endblock %}
 
 {% block primary %}
+  {% set guidance %}
+    <p class="govuk-body">You can apply to up to 3 courses at this stage of your application.</p>
+    <p class="govuk-body">Not all courses and training providers are signed up to Apply for teacher training. If you choose a course that isn’t signed up to the service, you’ll be directed to UCAS to continue your application.</p>
+    <p class="govuk-body">You can preview <a href="/apply/providers">courses currently available</a> on Apply for teacher training.</p>
+  {% endset %}
+
   {% if choices %}
     {% set referrer = applicationPath + "/choices" %}
     {% set canAmend = true %}
@@ -36,6 +42,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {% if not choices or choiceCount == 0 %}
+        {{ guidance | safe }}
+
         {{ govukButton({
           text: "Continue",
           href: applicationPath + "/choices/add"

--- a/app/views/application/choices/index.njk
+++ b/app/views/application/choices/index.njk
@@ -6,9 +6,17 @@
 {% set choices = applicationValue("choices") | toArray %}
 {% set choiceCount = choices | length %}
 {% if choiceCount >= 1 %}
-  {% set title = "Course choices" %}
+  {% if applicationValue(["apply2"]) %}
+    {% set title = "Course choice" %}
+  {% else %}
+    {% set title = "Course choices" %}
+  {% endif %}
 {% else %}
-  {% set title = "Choosing courses" %}
+  {% if applicationValue(["apply2"]) %}
+    {% set title = "Choosing a course" %}
+  {% else %}
+    {% set title = "Choosing courses" %}
+  {% endif %}
 {% endif %}
 
 {% block pageNavigation %}
@@ -28,7 +36,11 @@
 
 {% block primary %}
   {% set guidance %}
-    <p class="govuk-body">You can apply to up to 3 courses at this stage of your application.</p>
+    {% if applicationValue(["apply2"]) %}
+      <p class="govuk-body">You can only apply to 1 course at a time at this stage of your application.</p>
+    {% else %}
+      <p class="govuk-body">You can apply to up to 3 courses at this stage of your application.</p>
+    {% endif %}
     <p class="govuk-body">Not all courses and training providers are signed up to Apply for teacher training. If you choose a course that isn’t signed up to the service, you’ll be directed to UCAS to continue your application.</p>
     <p class="govuk-body">You can preview <a href="/apply/providers">courses currently available</a> on Apply for teacher training.</p>
   {% endset %}

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -14,6 +14,16 @@
 {% endif %}
 {% set hasSecondary = true %}
 
+{% block beforePageTitle %}
+  {% if showCopiedBanner %}
+    {{ appBanner({
+      html: "<h2 class=\"govuk-heading-m\">We’ve copied your application</h2>",
+      type: "success",
+      icon: false
+    }) }}
+  {% endif %}
+{% endblock %}
+
 {% block pageNavigation %}
   {% if hasSubmittedApplications() %}
     {{ govukBreadcrumbs({

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -37,11 +37,16 @@
     text: "You have 5 days remaining (until " + (7 | nowPlusDays("d MMMM yyyy")) + ") to submit your edited application",
     iconFallbackText: "Warning"
   }) if status == "amending" }}
-  <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">Course choices</h2>
+
+  {% if applicationValue(["apply2"]) %}
+    <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">Course choice</h2>
+  {% else %}
+    <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">Course choices</h2>
+  {% endif %}
   {{ appTaskList({
     classes: "govuk-!-margin-bottom-8",
     items: [{
-      text: "Course choices",
+      text: "Course choice" if applicationValue(["apply2"]) else "Course choices",
       href: applicationPath + "/choices",
       id: "personal-details",
       tag: {

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -2,7 +2,11 @@
 {% set applicationPath = "/application/" + applicationId %}
 {% set status = applicationValue(["status"]) %}
 {% if status == "started" %}
-  {% set title = "Your application" %}
+  {% if applicationValue('apply2') %}
+    {% set title = "Your new application" %}
+  {% else %}
+    {% set title = "Your application" %}
+  {% endif %}
   {% set tagClass = "app-tag--completed" %}
   {% set tagText = "Completed" %}
   {% set reviewText = "Check your answers before submitting" %}

--- a/app/views/application/review.njk
+++ b/app/views/application/review.njk
@@ -28,7 +28,11 @@
     text: "Please review your changes carefully before you resubmit. Your application can only be resubmitted once."
   }) if status == "amending" }}
 
-  <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
+  {% if applicationValue(["apply2"]) %}
+    <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">Course</h2>
+  {% else %}
+    <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">Courses</h2>
+  {% endif %}
   {% set choices = applicationValue(["choices"]) | toArray %}
   {% set showChoiceStatus = false %}
   {% set showIncomplete = true %}

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -27,7 +27,7 @@
 
 {% block beforePrimary %}
 
-  {% set needsReferee = true %}
+  {% set needsReferee = false %}
   {% if needsReferee %}
     {# <div class="app-banner">
       <h2 class="govuk-heading-m govuk-!-margin-bottom-0" id="success-message">
@@ -41,6 +41,12 @@
       </h2>
     </div>
   {% endif %}
+
+  <div class="app-banner">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-0" id="success-message">
+      <a href="/application/{{ applicationId }}/apply-again">Do you want to apply again?</a>
+    </h2>
+  </div>
 
   {# <div class="app-banner app-banner--success">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-0" id="success-message">


### PR DESCRIPTION
For review:
- This PR mostly focuses on the logic/mechanics.
- Much of the content here is placeholder
- Pages and banners have content that is there as a good starting point

Changes:
- Course choices becomes Course choice
- 3 choices becomes 1 choice in guidance
- Remove add another course flow and button
- Add an apply again page, link to it from the dashboard
- Show a copied banner when a new application is made
- Tweak Apply 2 application title to be "Your new application"
- Suggested placement for link to previous applications
- Show reference statuses on an Apply 2 application
- Make references read only (you can replace or delete but not change aspects of)

## Screenshots

![Screen Shot 2020-03-16 at 12 59 55](https://user-images.githubusercontent.com/319055/76760883-68d09480-6786-11ea-9a00-5b3cc7569181.png)

![Screen Shot 2020-03-16 at 11 23 14](https://user-images.githubusercontent.com/319055/76760896-6ec67580-6786-11ea-9fdd-5bcd2b4e0a1b.png)

![Screen Shot 2020-03-16 at 13 04 12](https://user-images.githubusercontent.com/319055/76761083-ac2b0300-6786-11ea-8617-5c00e741edd6.png)

![Screen Shot 2020-03-16 at 12 37 59](https://user-images.githubusercontent.com/319055/76761094-afbe8a00-6786-11ea-8d28-531d443fea13.png)
