### PR TITLE
Reason for withdrawal

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -22,7 +22,6 @@ module.exports = {
     nationality: process.env.MVP !== 'true',
     self_amend: process.env.MVP !== 'true',
     self_amend_contact_details: process.env.MVP !== 'true',
-    self_withdraw: process.env.MVP !== 'true',
     interview_preferences: true
   },
   // applications: (process.env.PRODUCTION === 'true') ? {} : testData

--- a/app/routes/application/decision.js
+++ b/app/routes/application/decision.js
@@ -21,6 +21,26 @@ module.exports = router => {
     })
   })
 
+  // Render withdraw confirmation page
+  router.get('/application/:applicationId/:choiceId/withdraw/confirmation', (req, res) => {
+    const { applicationId, choiceId } = req.params
+    const { phase, referrer } = req.query
+    const application = req.session.data.applications[applicationId]
+
+    const choice = application.choices[choiceId]
+    const provider = providers[choice.providerCode]
+    const course = provider.courses[choice.courseCode]
+
+    res.render('application/decision/withdraw-confirmation', {
+      provider,
+      course,
+      choice,
+      choiceId,
+      referrer,
+      phase
+    })
+  })
+
   // Submit decision
   router.post('/application/:applicationId/:choiceId/view', (req, res) => {
     const { applicationId, choiceId } = req.params

--- a/app/routes/email.js
+++ b/app/routes/email.js
@@ -172,10 +172,14 @@ module.exports = router => {
       conditionsList: urChoices[2].conditionsList
     })
 
-    if (phase) {
-      res.redirect(`/applications?phase=${phase}`)
+    if (decision === 'withdraw') {
+      res.redirect(`/application/${applicationId}/${choiceId}/withdraw/confirmation`)
     } else {
-      res.redirect('/applications')
+      if (phase) {
+        res.redirect(`/applications?phase=${phase}`)
+      } else {
+        res.redirect('/applications')
+      }
     }
   })
 }

--- a/app/views/application/decision/withdraw-confirmation.njk
+++ b/app/views/application/decision/withdraw-confirmation.njk
@@ -1,0 +1,85 @@
+{% extends "_form.njk" %}
+
+{% set title = "Course choice withdrawn" %}
+{% set formaction = "/applications" %}
+
+{% block content %}
+<form{% if formaction %} action="{{ formaction }}"{% endif %} method="post">
+  {{ govukPanel({
+    classes: "govuk-!-margin-bottom-8",
+    titleText: title,
+    text: "We will let " + provider.name + " know that you have withdrawn your application for " + course.name_and_code
+  }) }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% set reasonHtml %}
+        {{ govukTextarea({
+          label: {
+            text: "Please explain your reason for withdrawing from this course."
+          },
+          hint: {
+            text: "Your provider will not see this feedback."
+          }
+        } | decorateApplicationAttributes(["withdrawal-reason"])) }}
+      {% endset %}
+
+      {% set contactDetailsHtml %}
+        {{ govukTextarea({
+          label: {
+            text: "Please let us know when you’re available and give a phone number"
+          }
+        } | decorateApplicationAttributes(["withdrawal-contact-details"])) }}
+      {% endset %}
+
+      {{ govukRadios({
+        classes: "govuk-radios--inline",
+        fieldset: {
+          legend: {
+            text: "Do you have a reason for withdrawing?",
+            classes: "govuk-fieldset__legend--m"
+          }
+        },
+        id: "guidance-rating",
+        name: "guidance-rating",
+        items: [{
+          text: 'Yes, I’d like to share my reason with the Department for Education',
+          conditional: {
+            html: reasonHtml
+          }
+        }, {
+          text: 'I’d prefer not to say'
+        }]
+      }) }}
+
+      {{ govukRadios({
+        idPrefix: "withdrawal-research",
+        name: "withdrawal[research]",
+        value: withdrawal["research"],
+        fieldset: {
+          legend: {
+            html: "Can we contact you about your experience of withdrawing?",
+            classes: "govuk-label--m"
+          }
+        },
+        hint: {
+          text: "We’d ideally like to speak on the phone for half an hour."
+        },
+        items: [{
+          value: "yes",
+          text: "Yes, you can contact me",
+          conditional: {
+            html: contactDetailsHtml
+          }
+        }, {
+          value: "no",
+          text: "No, do not contact me"
+        }]
+      }) }}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/app/views/application/decision/withdraw-confirmation.njk
+++ b/app/views/application/decision/withdraw-confirmation.njk
@@ -57,7 +57,7 @@
         value: withdrawal["research"],
         fieldset: {
           legend: {
-            html: "Can we contact you about your experience of withdrawing?",
+            html: "Can we contact you about your experience of using this&nbsp;service?",
             classes: "govuk-label--m"
           }
         },

--- a/app/views/application/decision/withdraw.njk
+++ b/app/views/application/decision/withdraw.njk
@@ -12,8 +12,6 @@
 {% block primary %}
   {% include "_includes/item/offer.njk" %}
 
-  <p class="govuk-body">If you withdraw this course choice (and all your other course choices), you can still apply for more courses this year through <a href="https://2020.teachertraining.apply.ucas.com/apply/student/login.do">UCAS Teacher Training</a>.</p>
-
   {{ govukButton({
     classes: "govuk-button--warning",
     text: "Yes I’m sure - withdraw this course choice",

--- a/app/views/application/decision/withdraw.njk
+++ b/app/views/application/decision/withdraw.njk
@@ -1,11 +1,7 @@
 {% extends "_form.njk" %}
 
-{% if data.flags.self_withdraw %}
-  {% set title = "Are you sure you want to withdraw this course choice?" %}
-  {% set formaction = "/send-email/" + applicationId + "/" + choiceId + "/decision" %}
-{% else %}
-  {% set title = "Withdrawal" %}
-{% endif %}
+{% set title = "Are you sure you want to withdraw this course choice?" %}
+{% set formaction = "/send-email/" + applicationId + "/" + choiceId + "/decision" %}
 
 {% block pageNavigation %}
   {{ govukBackLink({
@@ -14,21 +10,14 @@
 {% endblock %}
 
 {% block primary %}
-  {% if data.flags.self_withdraw %}
-    {% include "_includes/item/offer.njk" %}
+  {% include "_includes/item/offer.njk" %}
 
-    <p class="govuk-body">If you withdraw this course choice (and all your other course choices), you can still apply for more courses this year through <a href="https://2020.teachertraining.apply.ucas.com/apply/student/login.do">UCAS Teacher Training</a>.</p>
+  <p class="govuk-body">If you withdraw this course choice (and all your other course choices), you can still apply for more courses this year through <a href="https://2020.teachertraining.apply.ucas.com/apply/student/login.do">UCAS Teacher Training</a>.</p>
 
-    {{ govukButton({
-      classes: "govuk-button--warning",
-      text: "Yes I’m sure - withdraw this course choice",
-      name: "decision",
-      value: "withdraw"
-    }) }}
-  {% else %}
-    <p class="govuk-body">You can withdraw your application to study:</p>
-    <p class="govuk-body"><strong>{{ course.name_and_code }} at {{ provider.name }}</strong></p>
-    <p class="govuk-body">by emailing us at <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
-    <p class="govuk-body">We’ll contact your training provider and send you an email confirming that your application has been withdrawn.</p>
-  {% endif %}
+  {{ govukButton({
+    classes: "govuk-button--warning",
+    text: "Yes I’m sure - withdraw this course choice",
+    name: "decision",
+    value: "withdraw"
+  }) }}
 {% endblock %}


### PR DESCRIPTION
### Withdraw (no change)

![withdraw](https://user-images.githubusercontent.com/813383/79773347-430c5180-8329-11ea-899f-457618a32c0b.png)

### Withdraw confirmation

After you withdraw, now show a confirmation screen, which asks 2 questions:

* Do you have a reason for withdrawing?
* Can we contact you about your experience of withdrawing?

We make it clear that feedback will only be shared with the Department for Education, and reinforce this again if candidate selects ‘Yes’ to the first question.  

![withdraw-confirmation](https://user-images.githubusercontent.com/813383/79773788-cc238880-8329-11ea-9aba-b8cf070c0305.png)

Selection ‘Yes’ to either, show the following free text areas:

![withdraw-confirmation-options](https://user-images.githubusercontent.com/813383/79773774-c8900180-8329-11ea-8b37-fbfb502f6c5a.png)

