### PR TITLE
Apply 2: Revert status tags

### DIFF
--- a/app/data/dummy-application.js
+++ b/app/data/dummy-application.js
@@ -35,7 +35,21 @@ module.exports = {
     }
   },
   completed: {
-
+    'personal-details': ['true'],
+    'contact-details': ['true'],
+    'work-history': ['true'],
+    'school-experience': ['true'],
+    'reasonable-adjustments': ['true'],
+    suitability: ['true'],
+    degree: ['true'],
+    maths: ['true'],
+    english: ['true'],
+    science: ['true'],
+    'other-qualifications': ['true'],
+    'personal-statement': ['true'],
+    'subject-knowledge': ['true'],
+    interview: ['true'],
+    references: ['true']
   },
   candidate: {
     'given-name': 'Janina',

--- a/app/data/dummy-apply-2-application.js
+++ b/app/data/dummy-apply-2-application.js
@@ -6,7 +6,7 @@ dummyApply2Application.apply2 = true
 dummyApply2Application.previousApplications = ['12345']
 
 // No sections completed
-dummyApply2Application.completed = {}
+dummyApply2Application.completed.choices = null
 
 // No choices yet
 dummyApply2Application.choices = {}

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -172,9 +172,7 @@ module.exports = router => {
     apply2Application.welcomeFlow = false
     apply2Application.apply2 = true
     apply2Application.choices = {}
-    apply2Application.completed = {
-      // 'personal-details': ['true']
-    }
+    apply2Application.completed.choices = false
     apply2Application.previousApplications = [existingApplicationId]
 
     if (apply2Application.referees && apply2Application.referees.first) {

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -1,8 +1,8 @@
 {% extends "_content.njk" %}
 {% set applicationPath = "/application/" + applicationId %}
 {% set status = applicationValue(["status"]) %}
-{% set incompleteTagClass = "govuk-tag--yellow" %}
-{% set incompleteTagText = "In progress" %}
+{% set incompleteTagClass = "govuk-tag--grey" %}
+{% set incompleteTagText = "Incomplete" %}
 {% set notStartedTagClass = "govuk-tag--grey" %}
 {% set notStartedTagText = "Not started" %}
 {% set referrer = applicationPath %}


### PR DESCRIPTION
This is just one of the changes that came out of Apply 2 actions; I’m doing this now as the ‘In progress’ tags may cause issues for international UR which follows the Apply 1 journey.

* Changes ‘In progress’ to ‘Incomplete’ (across both Apply 1 & 2)
* Changes incomplete tag to grey
* Mark all sections as completed (except for course choices) when copying an application for Apply 2