### PR TITLE
Suggest candidates choose a course first when applying again

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -161,6 +161,11 @@ module.exports = router => {
     res.render('application/index', { showCopiedBanner })
   })
 
+  // Render before you start page
+  router.all('/application/:applicationId/before-you-start', (req, res) => {
+    res.render('application/before-you-start', { showCopiedBanner: req.query.copied })
+  })
+
   // Generate apply2 application from an existing one
   router.get('/application/:applicationId/apply2', (req, res) => {
     const code = 12346
@@ -185,7 +190,7 @@ module.exports = router => {
 
     data.applications[code] = apply2Application
 
-    res.redirect(`/application/${code}?copied=true`)
+    res.redirect(`/application/${code}/before-you-start?copied=true`)
   })
 
   // Render previous applications

--- a/app/views/_content.njk
+++ b/app/views/_content.njk
@@ -5,10 +5,14 @@
 
   {% block beforePrimary %}
     {% if title %}
-      <h1 class="govuk-heading-xl">
-        {% if parent %}<span class="govuk-caption-xl">{{ parent }}</span>{% endif %}
-        {{ title | safe }}
-      </h1>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">
+          {% if parent %}<span class="govuk-caption-xl">{{ parent }}</span>{% endif %}
+          {{ title | safe }}
+        </h1>
+      </div>
+    </div>
     {% endif %}
   {% endblock %}
 

--- a/app/views/application/apply-again.njk
+++ b/app/views/application/apply-again.njk
@@ -11,7 +11,7 @@
     <li>keep your references, so you will not need to request new ones</li>
   </ul>
 
-  <p>You can only apply to 1 course at a time at this stage of your application.</p>
+  <p>You can only apply to one course at a time at this stage of your application.</p>
 
   <hr class="govuk-section-break govuk-section-break--m">
   {{ govukButton({

--- a/app/views/application/apply-again.njk
+++ b/app/views/application/apply-again.njk
@@ -7,8 +7,8 @@
 
   <p>If you apply again you can:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>edit your saved application, so you don’t need to start again</li>
-    <li>keep your references so you won’t need to request new ones</li>
+    <li>edit your saved application, so you do not need to start again</li>
+    <li>keep your references, so you will not need to request new ones</li>
   </ul>
 
   <p>You can only apply to 1 course at a time at this stage of your application.</p>

--- a/app/views/application/apply-again.njk
+++ b/app/views/application/apply-again.njk
@@ -3,12 +3,11 @@
 {% set title = "Do you want to apply again?" %}
 
 {% block primary %}
-  <p>Your first application did not lead to a place on a course.</p>
+  <p>You could still get a place on a course this year.</p>
 
-  <p>If you apply again we’ll:</p>
+  <p>If you apply again you can:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>copy your application so you don’t need to start again</li>
-    <li>let you make changes to each section</li>
+    <li>edit your saved application, so you don’t need to start again</li>
     <li>keep your references so you won’t need to request new ones</li>
   </ul>
 

--- a/app/views/application/before-you-start.njk
+++ b/app/views/application/before-you-start.njk
@@ -1,19 +1,29 @@
 {% extends "_content.njk" %}
-
 {% set title = "We suggest you choose a course first" %}
 
 {% block beforePageTitle %}
-  {{ appBanner({
-    html: "<h2 class=\"govuk-heading-m\">Your Apply for teacher training account has been created</h2>",
-    type: "success",
-    icon: false
-  }) }}
+  {% if showCopiedBanner %}
+    {{ appBanner({
+      html: "<h2 class=\"govuk-heading-m\">Your new application is ready for editing</h2>",
+      type: "success",
+      icon: false
+    }) }}
+  {% else %}
+    {{ appBanner({
+      html: "<h2 class=\"govuk-heading-m\">Your Apply for teacher training account has been created</h2>",
+      type: "success",
+      icon: false
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block primary %}
   <p>Apply for teacher training is a new GOV.UK service that will eventually replace UCAS. For now, you can only apply to some courses using this service.</p>
-  <p>By choosing a course first, you can check it’s available before you complete the rest of your application.</p>
-  <p>If you choose a course which is not available on Apply for teacher training, you’ll be guided back to UCAS to make an application.</p>
+
+  <p>By choosing a course first, you can check it’s available before you {% if applicationValue('apply2') %}edit{% else %}complete{% endif %} your application.</p>
+
+  <p>If your course is not available, you’ll be guided to UCAS to make an application.</p>
+
   <hr class="govuk-section-break govuk-section-break--m">
   {{ govukButton({
     classes: "govuk-!-margin-bottom-5",


### PR DESCRIPTION
There’s a gap in the current design for apply 2 in that users make a copy of their application before choosing a course. This means that someone could do this, start amending bits of their application, and then choose a course only to realise it’s on UCAS.

After applying again, take users to the "We suggest you choose a course first" page rather than their application. This is consistent with their first application.

Also:
- Update language to avoid "copying", instead infer more of a continuation
- Be more aspirational on the interstitial

https://trello.com/c/fiQBqrbp/1404-apply-2-initial-flow-choosing-a-course