### PR TITLE
Tweaks for accepting or declining offers

### DIFF
--- a/app/views/application/decision/accept.njk
+++ b/app/views/application/decision/accept.njk
@@ -12,11 +12,15 @@
 {% block primary %}
   {% include "_includes/item/offer.njk" %}
 
-  <p class="govuk-body">By accepting this offer, you confirm that:</p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>you understand any other applications made through Apply for teacher training will be automatically withdrawn</li>
-    <li>you have not accepted any other offers of teacher training places (for example through UCAS Teacher Training)</li>
-  </ul>
+  {% if applicationValue('apply2') %}
+    <p class="govuk-body">By accepting this offer you confirm that you have not accepted any other offers of teacher training places (for example through UCAS Teacher Training).</p>
+  {% else %}
+    <p class="govuk-body">By accepting this offer, you confirm that:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>you understand any other applications made through Apply for teacher training will be automatically withdrawn</li>
+      <li>you have not accepted any other offers of teacher training places (for example through UCAS Teacher Training)</li>
+    </ul>
+  {% endif %}
 
   {{ govukButton({
     text: "Accept offer",

--- a/app/views/application/decision/decline.njk
+++ b/app/views/application/decision/decline.njk
@@ -12,7 +12,7 @@
 {% block primary %}
   {% include "_includes/item/offer.njk" %}
 
-  <p class="govuk-body">If you decline this offer (and all other offers on current applications) you can still apply for more courses this year through <a href="https://2020.teachertraining.apply.ucas.com/apply/student/login.do">UCAS Teacher Training</a>.</p>
+  <p class="govuk-body">If you decline this offer{% if not applicationValue('apply2') %} (and all other offers on current applications){% endif %} you can still apply for more courses this year.</p>
 
   {{ govukButton({
     classes: "govuk-button--warning",

--- a/app/views/application/decision/withdraw.njk
+++ b/app/views/application/decision/withdraw.njk
@@ -12,6 +12,8 @@
 {% block primary %}
   {% include "_includes/item/offer.njk" %}
 
+  <p class="govuk-body">If you withdraw this course choice{% if not applicationValue('apply2') %} (and all your other course choices){% endif %} you can still apply for more courses this&nbsp;year.</p>
+
   {{ govukButton({
     classes: "govuk-button--warning",
     text: "Yes I’m sure - withdraw this course choice",


### PR DESCRIPTION
“Are you sure you want to accept offer” contained guidance on withdrawing other choices that’s not relevant when applying again (there’s only 1 choice).

“Are you sure you want to decline offer” contains guidance about applying again through UCAS, when this feature is launched apply again will not be specific to UCAS.

The updated content removes mention of:

- UCAS when suggesting a candidate can apply again after declining
- the caveat about “all other offers” when declining an offer on an application with 1 choice
- automatically withdrawing other choices when accepting an offer on an application with 1 choice

These changes should also apply to first applications that have only 1 choice.