### PR TITLE
Editing a course choice post submission

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/app/assets/sass/components/_banner.scss
+++ b/app/assets/sass/components/_banner.scss
@@ -28,6 +28,12 @@
 
 .app-banner--info {
   border-color: govuk-colour("blue");
+
+  .app-banner__message {
+    @include govuk-typography-weight-bold;
+    color: govuk-colour("blue");
+    margin-bottom: govuk-spacing(3);
+  }
 }
 
 .app-banner--success {
@@ -46,8 +52,10 @@
   }
 
   &.app-banner--missing-section {
-    .app-banner__message p {
+    .app-banner__message {
+      @include govuk-typography-weight-bold;
       color: govuk-colour("red");
+      margin-bottom: govuk-spacing(3);
     }
   }
 }

--- a/app/filters.js
+++ b/app/filters.js
@@ -172,6 +172,7 @@ module.exports = (env) => {
       case 'Declined':
         return 'govuk-tag--orange'
       case 'Rejected':
+      case 'Not available':
         return 'govuk-tag--red'
       case 'Accepted':
         return 'govuk-tag--blue'

--- a/app/routes.js
+++ b/app/routes.js
@@ -25,7 +25,7 @@ require('./routes/email')(router)
 
 // Clear all data in session if you open /admin/clear-data
 router.post('/admin/clear-data', function (req, res) {
-  req.session.data = {}
+  delete req.session.data
   res.render('admin/clear-data-success')
 })
 

--- a/app/routes/application/edit.js
+++ b/app/routes/application/edit.js
@@ -1,6 +1,6 @@
 module.exports = router => {
   router.get('/application/:applicationId/edit', (req, res) => {
-    res.render('application/edit')
+    res.render('application/edit/index.njk')
   })
 
   router.post('/application/:applicationId/edit', (req, res) => {

--- a/app/routes/delete.js
+++ b/app/routes/delete.js
@@ -6,12 +6,14 @@ module.exports = router => {
     const { id, section } = req.params
     const { phase, referrer } = req.query
     const item = applicationData[section][id]
+    const provider = utils.getProvider(item.providerCode);
+    const course = utils.getCourse(item.providerCode, item.courseCode);
 
     let parent
     let type
     switch (section) {
       case 'choices': {
-        parent = item.type ? `${item.providerCode} ${item.courseCode}` : 'Course choices'
+        parent = item.type ? `${provider.name} - ${course.name_and_code}` : 'Course choices'
         type = 'choice'
         break
       }

--- a/app/views/_includes/item/choice.njk
+++ b/app/views/_includes/item/choice.njk
@@ -3,13 +3,14 @@
 {% elif application.status == "amending" %}
   {% set appStatus = "Amending"%}
 {% endif %}
-{% set status = item.status or appStatus or "Submitted" %}
+{% set status = item.status or appStatus or "Pending" %}
 {% set statusHtml %}
   {{ govukTag({
     classes: "app-tag " + status | statusClass,
     text: status | capitalize
   }) }}
 {% endset %}
+
 {{ govukSummaryList({
   rows: [{
     key: {
@@ -42,7 +43,7 @@
     } if canAmend and not item.singleLocationCourse
   }, {
     key: {
-      text: "Full time or part time"
+      text: "Study mode"
     },
     value: {
       html: item.studyMode

--- a/app/views/_includes/review/choices.njk
+++ b/app/views/_includes/review/choices.njk
@@ -30,24 +30,43 @@
       or (item.status == "withdrawn")
     %}
 
-    {{ appSummaryCard({
-      classes: "govuk-!-margin-bottom-6",
-      headingLevel: 3,
-      titleText: provider.name,
-      actions: {
-        items: [{
-          href: applicationPath + "/choices/" + item.id + "/delete?referrer=" + referrer,
-          text: "Delete choice"
-        } if canAmend, {
-          href: applicationPath + "/" + item.id + "/withdraw",
-          text: "Withdraw"
-        } if canWithdraw, {
-          href: applicationPath + "/" + item.id + "/view?phase=" + phase,
-          text: "View and respond to offer"
-        } if canRespond and not hasResponded]
-      } if canAmend or canWithdraw or canRespond,
-      html: courseHtml
-    }) }}
+    {% set summaryCardHtml %}
+      {{ appSummaryCard({
+          classes: "govuk-!-margin-bottom-6",
+          headingLevel: 3,
+          titleText: provider.name,
+          actions: {
+            items: [{
+              href: applicationPath + "/choices/" + item.id + "/delete?referrer=" + referrer,
+              text: "Delete choice"
+            } if canAmend, {
+              href: applicationPath + "/" + item.id + "/withdraw",
+              text: "Withdraw"
+            } if canWithdraw, {
+              href: applicationPath + "/" + item.id + "/view?phase=" + phase,
+              text: "View and respond to offer"
+            } if canRespond and not hasResponded]
+          } if canAmend or canWithdraw or canRespond,
+          html: courseHtml
+        }) }}
+    {% endset %}
+
+    {% if item.status == 'Not available' %}
+      <div class="app-banner app-banner--missing-section app-banner--warning govuk-!-padding-bottom-0 govuk-!-padding-right-0">
+        <span class="app-banner__message">
+          <span class="govuk-visually-hidden">Error:</span> You cannot apply to ‘{{ provider.name }} – {{ course.name_and_code }}’ because it has no vacancies
+        </span>
+        <p>You can:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li><a href="{{ applicationPath + "/choices/" + item.id + "/delete?referrer=" + referrer }}">delete this choice</a></li>
+          <li><a href="{{ applicationPath + "/choices/" + item.id + "/provider?referrer=" + referrer }}">change to another course</a></li>
+          <li><a href="{{ applicationPath + "/choices/" + item.id + "/full?referrer=" + referrer }}">contact the training provider</a> to see if the course will re-open or discuss alternatives</li>
+        </ul>
+        {{ summaryCardHtml | safe }}
+      </div>
+    {% else %}
+     {{ summaryCardHtml | safe }}
+    {% endif %}
   {% endfor %}
 {% else %}
   {% if showIncomplete %}

--- a/app/views/application/choices/full.njk
+++ b/app/views/application/choices/full.njk
@@ -1,0 +1,42 @@
+{% extends "_content.njk" %}
+
+{% set parent = provider.name + " - " + course.name_and_code %}
+{% set title = "You cannot apply to this course because it has no vacancies" %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: referrer
+  }) }}
+{% endblock %}
+
+{% block primary %}
+  <p class="govuk-body">The course {{ course.name_and_code }} is full.</p>
+  <p class="govuk-body">You can:</p>
+  <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+    <li><a href="#">choose another course</a></li>
+    <li>contact Gorse SCITT to see if the course will re-open or discuss alternatives</li>
+  </ul>
+
+  <h2 class="govuk-heading-m">Contact Gorse SCITT</h2>
+  {{ govukSummaryList({
+    rows: [{
+      key: {
+        text: "Telephone"
+      },
+      value: {
+        text: "01234 321978"
+      }
+    }, {
+      key: {
+        text: "Email"
+      },
+      value: {
+        html: "<a href=\"#\">email@email.com</a>"
+      }
+    }]
+  }) }}
+
+  <p class="govuk-!-margin-top-8">
+    <a href="#">Return to your course choices</a>
+  </p>
+{% endblock %}

--- a/app/views/application/choices/index.njk
+++ b/app/views/application/choices/index.njk
@@ -1,9 +1,16 @@
 {% extends "_form-wide.njk" %}
 
 {% set applicationPath = "/application/" + applicationId %}
-{% set formaction = applicationPath %}
-{% set showChoiceStatus = false %}
-{% set choices = applicationValue("choices") | toArray %}
+{% set choices = choices | toArray %}
+{% if edit %}
+  {% set formaction = "/applications/?changed=true" %}
+  {% set referrer = applicationPath + "/choices/edit" %}
+  {% set showChoiceStatus = true %}
+{% else %}
+  {% set formaction = applicationPath %}
+  {% set referrer = applicationPath + "/choices" %}
+  {% set showChoiceStatus = false %}
+{% endif %}
 {% set choiceCount = choices | length %}
 {% if choiceCount >= 1 %}
   {% if applicationValue(["apply2"]) %}
@@ -20,16 +27,18 @@
 {% endif %}
 
 {% block pageNavigation %}
-  {% if not applicationValue('welcomeFlow') %}
-    {% if referrer %}
-      {{ govukBackLink({
-        href: referrer
-      }) }}
-    {% else %}
-      {{ govukBackLink({
-        href: "/application/" + applicationId,
-        text: "Back to application"
-      }) }}
+  {% if not edit %}
+    {% if not applicationValue('welcomeFlow') %}
+      {% if referrer %}
+        {{ govukBackLink({
+          href: referrer
+        }) }}
+      {% else %}
+        {{ govukBackLink({
+          href: "/application/" + applicationId,
+          text: "Back to application"
+        }) }}
+      {% endif %}
     {% endif %}
   {% endif %}
 {% endblock %}
@@ -46,41 +55,43 @@
   {% endset %}
 
   {% if choices %}
-    {% set referrer = applicationPath + "/choices" %}
     {% set canAmend = true %}
     {% include "_includes/review/choices.njk" %}
   {% endif %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      {% if not choices or choiceCount == 0 %}
-        {{ guidance | safe }}
+  {% if not choices or choiceCount == 0 %}
+    {{ guidance | safe }}
 
-        {{ govukButton({
-          text: "Continue",
-          href: applicationPath + "/choices/add"
-        }) }}
-      {% endif %}
+    {{ govukButton({
+      text: "Continue",
+      href: applicationPath + "/choices/add"
+    }) }}
+  {% endif %}
 
-      {% if choiceCount >= 1 and choiceCount < 3 and not applicationValue(["apply2"]) %}
-        {{ govukButton({
-          classes: "govuk-button--secondary govuk-!-margin-bottom-9",
-          text: "Add another course",
-          href: applicationPath + "/choices/add"
-        }) }}
-      {% endif %}
+  {% if choiceCount >= 1 and choiceCount < 3 and not applicationValue(["apply2"]) %}
+    {{ govukButton({
+      classes: "govuk-button--secondary",
+      text: "Add another course",
+      href: applicationPath + "/choices/add"
+    }) }}
+  {% endif %}
 
-      {% if choiceCount >= 1 %}
-        {{ govukCheckboxes({
-          items: [{
-            value: "true",
-            text: "I have completed this section"
-          }]
-        } | decorateApplicationAttributes(["completed", "choices"])) }}
-        {{ govukButton({
-          text: "Continue"
-        }) }}
-      {% endif %}
-    </div>
-  </div>
+  {% if not edit %}
+    {% if choiceCount >= 1 %}
+      {{ govukCheckboxes({
+        items: [{
+          value: "true",
+          text: "I have completed this section"
+        }]
+      } | decorateApplicationAttributes(["completed", "choices"])) }}
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+    {% endif %}
+  {% elif edit and canSubmit %}
+    <br>
+    {{ govukButton({
+      text: "Submit application with changes"
+    }) }}
+  {% endif %}
 {% endblock %}

--- a/app/views/application/choices/location.njk
+++ b/app/views/application/choices/location.njk
@@ -2,9 +2,10 @@
 
 {% set title = "Pick a course location" %}
 {% set formaction = paths.next %}
+
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: paths.back
+    href: referrer or paths.back
   }) }}
 {% endblock %}
 

--- a/app/views/application/choices/pick.njk
+++ b/app/views/application/choices/pick.njk
@@ -18,7 +18,7 @@
 
 {% block pageNavigation %}
   {{ govukBackLink({
-    href: paths.back
+    href: referrer or paths.back
   }) }}
 {% endblock %}
 

--- a/app/views/application/choices/provider.njk
+++ b/app/views/application/choices/provider.njk
@@ -2,11 +2,15 @@
 
 {% set title = "Which training provider are you applying to?" %}
 {% set formaction = paths.next %}
-{% block pageNavigation %}{{ govukBackLink({ href: paths.back }) }}{% endblock %}
+
+{% block pageNavigation %}
+  {{ govukBackLink({
+    href: referrer or paths.back
+  }) }}
+{% endblock %}
 
 {% block primary %}
-
-<p class="govuk-body">You can <a href="/apply/providers">preview a list of training providers and courses</a> currently available on Apply for teacher training.</p>
+  <p class="govuk-body">You can <a href="/apply/providers">preview a list of training providers and courses</a> currently available on Apply for teacher training.</p>
   {% set providerAutocompleteHTML %}
     <div class="govuk-form-group">
       <label class="govuk-label" for="courses-{{ choiceId }}-provider">Enter training provider name</label>

--- a/app/views/application/index.njk
+++ b/app/views/application/index.njk
@@ -24,13 +24,17 @@
 {% set hasSecondary = true %}
 
 {% block beforePageTitle %}
-  {% if showCopiedBanner %}
-    {{ appBanner({
-      html: "<h2 class=\"govuk-heading-m\">We’ve copied your application. Please review all sections.</h2>",
-      type: "success",
-      icon: false
-    }) }}
-  {% endif %}
+  {{ appBanner({
+    html: "<h2 class=\"govuk-heading-m\">We’ve updated your application.</h2>",
+    type: "success",
+    icon: false
+  }) if showChangesBanner }}
+
+  {{ appBanner({
+    html: "<h2 class=\"govuk-heading-m\">We’ve copied your application. Please review all sections.</h2>",
+    type: "success",
+    icon: false
+  }) if showCopiedBanner }}
 {% endblock %}
 
 {% block pageNavigation %}

--- a/app/views/applications/index.njk
+++ b/app/views/applications/index.njk
@@ -26,39 +26,40 @@
 {% endfor %}
 
 {% block beforePrimary %}
+  {% set showChangesBanner = true %}
+  {{ appBanner({
+    html: "<h2 class=\"govuk-heading-m\">We’ve updated your application and sent it to providers.</h2>",
+    type: "success",
+    icon: false
+  }) if showChangesBanner }}
+
+  {# appBanner({
+    html: "<h2 class=\"govuk-heading-m\"><a href=\"/application/" + applicationId + "/apply-again\">Do you want to apply again?</a></h2>",
+    icon: false
+  }) #}
 
   {% set needsReferee = false %}
-  {% if needsReferee %}
-    {# <div class="app-banner">
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-0" id="success-message">
-        You need to <a href="{{ applicationPath }}/references/alternative">give details of a new referee</a>
-      </h2>
-    </div> #}
+  {{ appBanner({
+    html: "<h2 class=\"govuk-heading-m\">You need to <a href=\"" + applicationPath + "/references/alternative\">give details of a new referee</h2>",
+    icon: false
+  }) if needsReferee }}
 
-    <div class="app-banner">
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-0" id="success-message">
-        You need to <a href="{{ applicationPath }}/references/alternative-first">give details of 2 new referees</a>
-      </h2>
-    </div>
-  {% endif %}
+  {# appBanner({
+    html: "<h2 class=\"govuk-heading-m\">You need to <a href=\"" + applicationPath + "/references/alternative-first\">give details of 2 new referees</h2>",
+    icon: false
+  }) if needsReferee #}
 
-  {# <div class="app-banner">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-0" id="success-message">
-      <a href="/application/{{ applicationId }}/apply-again">Do you want to apply again?</a>
-    </h2>
-  </div> #}
+  {# appBanner({
+    html: "<h2 class=\"govuk-heading-m\">Thank you. We’ve asked your new referee for a reference</h2>",
+    type: "success"
+    icon: false
+  }) #}
 
-  {# <div class="app-banner app-banner--success">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-0" id="success-message">
-      Thank you. We’ve asked your new referee for a reference
-    </h2>
-  </div> #}
-
-  {# <div class="app-banner app-banner--success">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-0" id="success-message">
-      Thank you. We’ve asked each new referee for a reference
-    </h2>
-  </div> #}
+  {# appBanner({
+    html: "<h2 class=\"govuk-heading-m\">Thank you. We’ve asked each new referee for a reference</h2>",
+    type: "success"
+    icon: false
+  }) #}
 
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">{{ title | safe }}</h1>
   <p class="govuk-hint govuk-!-margin-bottom-8">Application submitted on {{ "now" | date("d MMMM yyyy") }}. <a href="/application/{{ applicationId }}/submitted?phase={{ phase }}">View application</a></p>


### PR DESCRIPTION
In addition to the email, we’ll want to show a message on the dashboard, linking to the page where you can edit your course choices (it’s late – needs proper words!):

![dashboard-info](https://user-images.githubusercontent.com/813383/81852708-59d24c80-9553-11ea-9e59-1c41988d3b47.png)

* * *

Editing a course choice post-submission can reuse much of the same logic and patterns as that used on the pre-submission review page. Only changes being:

* We show the status of each course choice.
  * _Should the problematic course could show `Not available` as the status (or similar)?_
* There’s no need to mark this section as complete
* _Do we need some guidance at the head of this page?_

![course-choices](https://user-images.githubusercontent.com/813383/81851720-d6fcc200-9551-11ea-9e17-6fdbdb8545e7.png)

* * *

Once changes have been made which mean the application can be submitted, a ‘Submit application with changes’ button is shown. _Is this likely to be missed?_

![course-choices-edited](https://user-images.githubusercontent.com/813383/81851715-d2380e00-9551-11ea-9e13-99daed35b69c.png)

* * *

Upon submitting the edits, you are taken to the dashboard page where a success banner is shown.

![dashboard-success](https://user-images.githubusercontent.com/813383/81852722-5fc82d80-9553-11ea-8018-931b7e74d4d1.png)